### PR TITLE
Translation Fix

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/api/language/TranslationManager.java
+++ b/src/main/java/net/hypixel/nerdbot/api/language/TranslationManager.java
@@ -95,6 +95,10 @@ public class TranslationManager {
             }
 
             if (element == null) {
+                if (language != DEFAULT_LANGUAGE) {
+                    return translate(key, args);
+                }
+
                 return ERROR_MESSAGE.formatted(key);
             }
         }


### PR DESCRIPTION
Fixes an issue with translations if the given key did not exist in the user's language, it would complain about it not existing even if it did in the DEFAULT_LANGUAGE

Now we're also checking the DEFAULT_LANGUAGE for the key and displaying that instead, if it exists

If it still doesn't exist at that point it will display the error it did before