### PR TITLE
Add Abiphone Call Icon

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
+++ b/src/main/java/net/hypixel/nerdbot/util/skyblock/Icon.java
@@ -14,7 +14,8 @@ public enum Icon {
     STARRED("⚚", "Starred"),
     FRAGGED("⚚", "Starred"),
     BINGO("Ⓑ", "Bingo"),
-    ZONE("⏣", "Zone");
+    ZONE("⏣", "Zone"),
+    ABIPHONE("✆", "Abiphone Call");
 
     public static final Icon[] VALUES = values();
 


### PR DESCRIPTION
Adds `✆` as an icon to the bot so it can be used in the item generators