### PR TITLE
Fix ChannelType not identifying correctly

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/channel/AlphaProjectConfig.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/channel/AlphaProjectConfig.java
@@ -3,6 +3,7 @@ package net.hypixel.nerdbot.bot.config.channel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -16,6 +17,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@Log4j2
 @ToString
 public class AlphaProjectConfig {
 
@@ -72,8 +74,9 @@ public class AlphaProjectConfig {
 
         if (updateAlpha) {
             // Update Alpha Forum IDs (Alpha Takes Priority)
+            log.info("Updating Alpha Forum IDs");
             this.alphaForumIds = forumChannels.stream()
-                .filter(forumChannel -> Util.getChannelSuggestionType(forumChannel) == Suggestion.ChannelType.ALPHA)
+                .filter(forumChannel -> Util.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.ALPHA)
                 .map(ISnowflake::getId)
                 .toList()
                 .toArray(new String[]{});
@@ -81,8 +84,9 @@ public class AlphaProjectConfig {
 
         if (updateProject) {
             // Update Project Forum IDs
+            log.info("Updating Project Forum IDs");
             this.projectForumIds = forumChannels.stream()
-                .filter(forumChannel -> Util.getChannelSuggestionType(forumChannel) == Suggestion.ChannelType.PROJECT)
+                .filter(forumChannel -> Util.getForumSuggestionType(forumChannel) == Suggestion.ChannelType.PROJECT)
                 .map(ISnowflake::getId)
                 .toList()
                 .toArray(new String[]{});

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -127,12 +127,17 @@ public class ActivityListener {
         Suggestion.ChannelType channelType;
 
         if (guildChannel instanceof ThreadChannel threadChannel) {
+            log.info("getThreadSuggestionType for threadChannel: " + threadChannel.getName() + " (" + threadChannel.getId() + ")");
             channelType = Util.getThreadSuggestionType(threadChannel);
         } else if (guildChannel instanceof TextChannel) {
+            log.info("getChannelSuggestionType for TextChannel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
             channelType = Util.getChannelSuggestionType(guildChannel.asTextChannel());
         } else {
+            log.info("getChannelSuggestionTypeFromName for GuildChannel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
             channelType = Util.getChannelSuggestionTypeFromName(guildChannel.getName());
         }
+
+        log.info("Found ChannelType: " + channelType + " for channel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
 
         // New Suggestion Comments
         if (guildChannel instanceof ThreadChannel && event.getChannel().getIdLong() != event.getMessage().getIdLong()) {

--- a/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ActivityListener.java
@@ -127,17 +127,12 @@ public class ActivityListener {
         Suggestion.ChannelType channelType;
 
         if (guildChannel instanceof ThreadChannel threadChannel) {
-            log.info("getThreadSuggestionType for threadChannel: " + threadChannel.getName() + " (" + threadChannel.getId() + ")");
             channelType = Util.getThreadSuggestionType(threadChannel);
         } else if (guildChannel instanceof TextChannel) {
-            log.info("getChannelSuggestionType for TextChannel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
             channelType = Util.getChannelSuggestionType(guildChannel.asTextChannel());
         } else {
-            log.info("getChannelSuggestionTypeFromName for GuildChannel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
             channelType = Util.getChannelSuggestionTypeFromName(guildChannel.getName());
         }
-
-        log.info("Found ChannelType: " + channelType + " for channel: " + guildChannel.getName() + " (" + guildChannel.getId() + ")");
 
         // New Suggestion Comments
         if (guildChannel instanceof ThreadChannel && event.getChannel().getIdLong() != event.getMessage().getIdLong()) {

--- a/src/main/java/net/hypixel/nerdbot/util/Util.java
+++ b/src/main/java/net/hypixel/nerdbot/util/Util.java
@@ -250,9 +250,9 @@ public class Util {
         AlphaProjectConfig alphaProjectConfig = NerdBotApp.getBot().getConfig().getAlphaProjectConfig();
         String parentChannelId = forumChannel.getId();
 
-        if (Util.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(parentChannelId::equals)) {
+        if (Util.safeArrayStream(alphaProjectConfig.getAlphaForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
             return Suggestion.ChannelType.ALPHA;
-        } else if (Util.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(parentChannelId::equals)) {
+        } else if (Util.safeArrayStream(alphaProjectConfig.getProjectForumIds()).anyMatch(parentChannelId::equalsIgnoreCase)) {
             return Suggestion.ChannelType.PROJECT;
         } else if (parentChannelId.equals(suggestionConfig.getForumChannelId())) {
             return Suggestion.ChannelType.NORMAL;

--- a/src/main/java/net/hypixel/nerdbot/util/Util.java
+++ b/src/main/java/net/hypixel/nerdbot/util/Util.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
@@ -256,6 +257,16 @@ public class Util {
             return Suggestion.ChannelType.PROJECT;
         } else if (parentChannelId.equals(suggestionConfig.getForumChannelId())) {
             return Suggestion.ChannelType.NORMAL;
+        }
+
+        Category parentCategory = forumChannel.getParentCategory();
+
+        if (parentCategory != null) {
+            return getChannelSuggestionTypeFromName(parentCategory.getName());
+        }
+
+        if (forumChannel.getName().toLowerCase().contains("alpha") || Arrays.stream(PROJECT_CHANNEL_NAMES).anyMatch(forumChannel.getName().toLowerCase()::contains)) {
+            return getChannelSuggestionTypeFromName(forumChannel.getName());
         }
 
         return Suggestion.ChannelType.UNKNOWN;


### PR DESCRIPTION
In some cases the methods being used to determine the ChannelType of a channel were not correclty identifying the channel's type.

This _should_ be fixed now.