### PR TITLE
Support threads in Reaction Channels

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/bot/config/objects/ReactionChannel.java
+++ b/src/main/java/net/hypixel/nerdbot/bot/config/objects/ReactionChannel.java
@@ -17,6 +17,7 @@ public class ReactionChannel {
     private final String name;
     private final String discordChannelId;
     private final List<String> emojiIds;
+    private final boolean thread;
 
     public List<Emoji> getEmojis() {
         return emojiIds.stream()

--- a/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
@@ -38,7 +38,6 @@ public class ReactionChannelListener {
 
             if (reactionChannel.get().isThread()) {
                 message.createThreadChannel("Related messages here").queue(thread -> {
-                    thread.sendMessage("Thread created for message " + message.getId()).queue();
                     log.info("[Reaction Channel] Created thread for message " + message.getId() + " in reaction channel " + reactionChannel.get().getName());
                 });
             }

--- a/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
+++ b/src/main/java/net/hypixel/nerdbot/listener/ReactionChannelListener.java
@@ -18,6 +18,7 @@ public class ReactionChannelListener {
     @SubscribeEvent
     public void onMessageReceive(MessageReceivedEvent event) {
         List<ReactionChannel> reactionChannels = NerdBotApp.getBot().getConfig().getChannelConfig().getReactionChannels();
+
         if (reactionChannels == null) {
             return;
         }
@@ -25,17 +26,27 @@ public class ReactionChannelListener {
         Optional<ReactionChannel> reactionChannel = reactionChannels.stream()
             .filter(channel -> channel.getDiscordChannelId().equals(event.getChannel().getId()))
             .findFirst();
+
         if (reactionChannel.isPresent()) {
             Message message = event.getMessage();
+
             reactionChannel.get().getEmojis()
                 .forEach(emoji -> {
                     message.addReaction(emoji).queue();
-                    log.info("Added reaction '" + emoji.getName() + "' to message " + message.getId() + " in reaction channel " + reactionChannel.get().getName());
+                    log.info("[Reaction Channel] Added reaction '" + emoji.getName() + "' to message " + message.getId() + " in reaction channel " + reactionChannel.get().getName());
                 });
+
+            if (reactionChannel.get().isThread()) {
+                message.createThreadChannel("Related messages here").queue(thread -> {
+                    thread.sendMessage("Thread created for message " + message.getId()).queue();
+                    log.info("[Reaction Channel] Created thread for message " + message.getId() + " in reaction channel " + reactionChannel.get().getName());
+                });
+            }
             return;
         }
 
         String pollChannelId = NerdBotApp.getBot().getConfig().getChannelConfig().getPollChannelId();
+
         if (event.getChannel().getId().equalsIgnoreCase(pollChannelId)) {
             EmojiParser.extractEmojis(event.getMessage().getContentRaw()).stream()
                 .map(Emoji::fromUnicode)


### PR DESCRIPTION
Self explanatory

Uses a new boolean called `thread` in the configuration object for a reaction channel