### PR TITLE
Updated MinecraftTooltipGenerator.buildSlashCommand to fix a typo

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/MinecraftTooltipGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/MinecraftTooltipGenerator.java
@@ -221,7 +221,7 @@ public class MinecraftTooltipGenerator implements Generator {
          * @return A properly formatted slash command string.
          */
         public String buildSlashCommand() {
-            StringBuilder commandBuilder = new StringBuilder("/" + GeneratorCommands.BASE_COMMAND + " item ");
+            StringBuilder commandBuilder = new StringBuilder("/" + GeneratorCommands.BASE_COMMAND + " item full ");
             Field[] fields = this.getClass().getDeclaredFields();
 
             for (Field field : fields) {


### PR DESCRIPTION
It is currently parsing to `gen2 item ...` but should be `gen2 item full ...`

with the `...` being the fields