### PR TITLE
Feat v2 gen powerstone redo

### DIFF
--- a/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
+++ b/src/main/java/net/hypixel/nerdbot/command/GeneratorCommands.java
@@ -22,7 +22,6 @@ import net.hypixel.nerdbot.NerdBotApp;
 import net.hypixel.nerdbot.api.database.model.user.DiscordUser;
 import net.hypixel.nerdbot.generator.data.PowerStrength;
 import net.hypixel.nerdbot.generator.data.Rarity;
-import net.hypixel.nerdbot.generator.data.Stat;
 import net.hypixel.nerdbot.generator.exception.GeneratorException;
 import net.hypixel.nerdbot.generator.image.GeneratorImageBuilder;
 import net.hypixel.nerdbot.generator.impl.MinecraftInventoryGenerator;
@@ -219,7 +218,7 @@ public class GeneratorCommands extends ApplicationCommand {
             event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         }
-        catch (GeneratorException | IllegalArgumentException | InvalidPowerstoneStatFormatException exception){
+        catch (GeneratorException | IllegalArgumentException | InvalidPowerstoneStatFormatException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating a Power Stone", exception);
         }
@@ -303,7 +302,7 @@ public class GeneratorCommands extends ApplicationCommand {
             event.getHook().editOriginalAttachments(FileUpload.fromData(ImageUtil.toFile(generatedObject.getImage()), "item.png")).queue();
             addCommandToUserHistory(event.getUser(), event.getCommandString());
         }
-        catch (GeneratorException | IllegalArgumentException | InvalidPowerstoneStatFormatException exception){
+        catch (GeneratorException | IllegalArgumentException | InvalidPowerstoneStatFormatException exception) {
             event.getHook().editOriginal(exception.getMessage()).queue();
             log.error("Encountered an error while generating a Power Stone", exception);
         }

--- a/src/main/java/net/hypixel/nerdbot/generator/image/MinecraftTooltip.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/image/MinecraftTooltip.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import net.hypixel.nerdbot.command.GeneratorCommands;
 import net.hypixel.nerdbot.generator.builder.ClassBuilder;
 import net.hypixel.nerdbot.generator.text.ChatFormat;
 import net.hypixel.nerdbot.generator.text.segment.ColorSegment;

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/MinecraftTooltipGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/MinecraftTooltipGenerator.java
@@ -1,114 +1,91 @@
 package net.hypixel.nerdbot.generator.impl.tooltip;
 
-import com.google.gson.JsonObject;
 import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import net.hypixel.nerdbot.command.GeneratorCommands;
 import net.hypixel.nerdbot.generator.Generator;
 import net.hypixel.nerdbot.generator.builder.ClassBuilder;
-import net.hypixel.nerdbot.generator.data.Rarity;
-import net.hypixel.nerdbot.generator.exception.GeneratorException;
 import net.hypixel.nerdbot.generator.image.MinecraftTooltip;
 import net.hypixel.nerdbot.generator.item.GeneratedObject;
-import net.hypixel.nerdbot.generator.text.ChatFormat;
 import net.hypixel.nerdbot.generator.text.segment.LineSegment;
 import net.hypixel.nerdbot.generator.text.wrapper.TextWrapper;
 import net.hypixel.nerdbot.util.Range;
-import net.hypixel.nerdbot.util.Util;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.image.BufferedImage;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
 @Log4j2
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class MinecraftTooltipGenerator implements Generator {
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MinecraftTooltipGenerator<settings extends TooltipSettings> implements Generator {
 
     public static final int DEFAULT_MAX_LINE_LENGTH = 36;
 
-    private final String name;
-    private final Rarity rarity;
-    private final String itemLore;
-    private final String type;
-    private final boolean emptyLine;
-    private final int alpha;
-    private final int padding;
-    private final boolean normalItem;
-    private final boolean centeredText;
-    private final int maxLineLength;
-    private final boolean renderBorder;
+    protected final String name;
+    protected final boolean renderBorder;
+    protected final int maxLineLength;
+    protected final int padding;
+    protected final int alpha;
+    protected final String itemLore;
+    protected final boolean centeredText; // TODO: implement
 
     @Override
     public GeneratedObject generate() {
         TooltipSettings settings = new TooltipSettings(
-            name,           // Name of the item
-            emptyLine,      // Whether to add an empty line
-            type,           // Type of the item
-            alpha,          // Alpha value
-            padding,        // Padding value
-            normalItem,     // Whether to pad the first line
-            maxLineLength,  // Maximum line length
+            itemLore,
+            name,
+            alpha,
+            padding,
+            maxLineLength,
             renderBorder    // Whether to render a border around the tooltip
         );
 
-        return new GeneratedObject(buildItem(itemLore, settings));
+        return new GeneratedObject(buildItem((settings) settings));
     }
 
     /**
      * Builds an item tooltip image from a string of lore.
      *
-     * @param itemLoreString The lore string to parse
      * @param settings       The {@link TooltipSettings settings} to use for the generated tooltip image
      *
      * @return The generated tooltip image
      */
     @Nullable
-    public BufferedImage buildItem(String itemLoreString, TooltipSettings settings) {
-        return parseLore(itemLoreString, settings).render().getImage();
+    public BufferedImage buildItem(settings settings) {
+        return parseLore(settings).render().getImage();
     }
 
-    public MinecraftTooltip parseLore(String input, TooltipSettings settings) {
-        log.debug("Parsing lore for item: {} with TooltipSettings: {}", name, settings);
+    public MinecraftTooltip parseLore(settings settings) {
+        log.debug("Parsing lore for item: {} with TooltipSettings: {}", settings.getName(), settings);
 
         MinecraftTooltip.Builder builder = MinecraftTooltip.builder()
             .withPadding(settings.getPadding())
-            .isPaddingFirstLine(settings.isPaddingFirstLine())
             .setRenderBorder(settings.isRenderBorder())
             .withAlpha(Range.between(0, 255).fit(settings.getAlpha()));
 
         if (settings.getName() != null && !settings.getName().isEmpty()) {
             String name = settings.getName();
 
-            if (rarity != null && rarity != Rarity.byName("NONE")) {
-                name = rarity.getColorCode() + name;
-            }
-
             builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(name), '&'));
         }
 
-        List<List<LineSegment>> segments = new ArrayList<>();
-
-        for (String line : TextWrapper.wrapString(input, settings.getMaxLineLength())) {
-            segments.add(LineSegment.fromLegacy(line, '&'));
-        }
-
-        for (List<LineSegment> line : segments) {
+        for (List<LineSegment> line : stringLoreToLineSegements(settings.getLore(), settings.getMaxLineLength())) {
             builder.withLines(line);
         }
 
-        if (rarity != null && rarity != Rarity.byName("NONE")) {
-            if (settings.isEmptyLine()) {
-                builder.withEmptyLine();
-            }
-            builder.withLines(LineSegment.fromLegacy(rarity.getFormattedDisplay() + " " + settings.getType(), '&'));
+        return builder.build();
+    }
+
+    protected List<List<LineSegment>> stringLoreToLineSegements (String input, int maxLineLength) {
+        List<List<LineSegment>> segments = new ArrayList<>();
+
+        for (String line : TextWrapper.wrapString(input, maxLineLength)) {
+            segments.add(LineSegment.fromLegacy(line, '&'));
         }
 
-        return builder.build();
+        return segments;
     }
 
     public enum TooltipSide {
@@ -116,15 +93,11 @@ public class MinecraftTooltipGenerator implements Generator {
         RIGHT
     }
 
-    public static class Builder implements ClassBuilder<MinecraftTooltipGenerator> {
+    public static class Builder implements ClassBuilder<MinecraftTooltipGenerator<TooltipSettings>> {
         private String name;
-        private Rarity rarity;
         private String itemLore;
-        private String type;
-        private Boolean emptyLine;
         private Integer alpha;
         private Integer padding;
-        private boolean paddingFirstLine;
         private int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
         private transient boolean bypassMaxLineLength;
         private boolean centered;
@@ -135,23 +108,8 @@ public class MinecraftTooltipGenerator implements Generator {
             return this;
         }
 
-        public MinecraftTooltipGenerator.Builder withRarity(Rarity rarity) {
-            this.rarity = rarity;
-            return this;
-        }
-
         public MinecraftTooltipGenerator.Builder withItemLore(String itemLore) {
             this.itemLore = itemLore;
-            return this;
-        }
-
-        public MinecraftTooltipGenerator.Builder withType(String type) {
-            this.type = type;
-            return this;
-        }
-
-        public MinecraftTooltipGenerator.Builder withEmptyLine(boolean emptyLine) {
-            this.emptyLine = emptyLine;
             return this;
         }
 
@@ -162,11 +120,6 @@ public class MinecraftTooltipGenerator implements Generator {
 
         public MinecraftTooltipGenerator.Builder withPadding(int padding) {
             this.padding = padding;
-            return this;
-        }
-
-        public MinecraftTooltipGenerator.Builder isPaddingFirstLine(boolean paddingFirstLine) {
-            this.paddingFirstLine = paddingFirstLine;
             return this;
         }
 
@@ -194,70 +147,41 @@ public class MinecraftTooltipGenerator implements Generator {
             return this;
         }
 
-        // TODO support components
-        public MinecraftTooltipGenerator.Builder parseNbtJson(JsonObject nbtJson) {
-            this.emptyLine = false;
-            this.paddingFirstLine = false;
-            this.centered = false;
-            this.rarity = Rarity.byName("NONE");
-            this.itemLore = "";
-
-            JsonObject tagObject = nbtJson.get("tag").getAsJsonObject();
-            JsonObject displayObject = tagObject.get("display").getAsJsonObject();
-            this.name = displayObject.getAsJsonObject().get("Name").getAsString();
-
-            displayObject.getAsJsonObject().get("Lore").getAsJsonArray().forEach(jsonElement -> {
-                this.itemLore += jsonElement.getAsString() + "\\n";
-            });
-
-            this.itemLore = this.itemLore.replaceAll(String.valueOf(ChatFormat.SECTION_SYMBOL), String.valueOf(ChatFormat.AMPERSAND_SYMBOL));
-
-            return this;
-        }
-
-        /**
-         * Builds a slash command from the current state of the builder.
-         *
-         * @return A properly formatted slash command string.
-         */
         public String buildSlashCommand() {
-            StringBuilder commandBuilder = new StringBuilder("/" + GeneratorCommands.BASE_COMMAND + " item full ");
-            Field[] fields = this.getClass().getDeclaredFields();
+            StringBuilder commandBuilder = new StringBuilder("/" + GeneratorCommands.BASE_COMMAND + " item full"); //TODO if there ever is a more suitable command use that instead
 
-            for (Field field : fields) {
-                try {
-                    field.setAccessible(true);
-
-                    int modifiers = field.getModifiers();
-                    if (Modifier.isTransient(modifiers)) {
-                        continue;
-                    }
-
-                    Object value = field.get(this);
-                    if (value != null && !(value instanceof String string && string.isEmpty())) {
-                        String paramName = Util.convertCamelCaseToSnakeCase(field.getName());
-
-                        commandBuilder.append(paramName).append(": ");
-
-                        if (value instanceof Boolean bool) {
-                            commandBuilder.append(StringUtils.capitalize(bool.toString())); // Discord slash commands use "True" and "False" for booleans
-                        } else {
-                            commandBuilder.append(value);
-                        }
-
-                        commandBuilder.append(" ");
-                    }
-                } catch (IllegalAccessException e) {
-                    throw new GeneratorException("Failed to build slash command", e);
-                }
+            if (name != null && !name.isEmpty()) {
+                commandBuilder.append(" name:").append(name);
             }
 
-            return commandBuilder.toString().trim();
+            if (itemLore != null && !itemLore.isEmpty()) {
+                commandBuilder.append(" item_lore:").append(itemLore);
+            }
+
+            if (alpha != null) {
+                commandBuilder.append(" alpha:").append(alpha);
+            }
+
+            if (padding != null) {
+                commandBuilder.append(" padding:").append(padding);
+            }
+
+            commandBuilder.append(" max_line_length:").append(maxLineLength);
+
+            if (bypassMaxLineLength) {
+                commandBuilder.append(" bypass_max_line_length:true");
+            }
+
+            commandBuilder.append(" centered:").append(centered);
+
+            commandBuilder.append(" render_border:").append(renderBorder);
+
+            return commandBuilder.toString();
         }
 
         @Override
-        public MinecraftTooltipGenerator build() {
-            return new MinecraftTooltipGenerator(name, rarity, itemLore, type, emptyLine, alpha, padding, paddingFirstLine, centered, maxLineLength, renderBorder);
+        public MinecraftTooltipGenerator<TooltipSettings> build() {
+            return new MinecraftTooltipGenerator<>(name, renderBorder, maxLineLength, padding, alpha, itemLore, centered);
         }
     }
 }

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/TooltipSettings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/TooltipSettings.java
@@ -11,14 +11,11 @@ import lombok.ToString;
 @ToString
 public class TooltipSettings {
 
-    private final String name;
-    private final boolean emptyLine;
-    private final String type;
-    private final int alpha;
-    private final int padding;
-    private final boolean paddingFirstLine;
-    private final int maxLineLength;
-    private final boolean renderBorder;
+    protected final String lore;
+    protected final String name;
+    protected final int alpha;
+    protected final int padding;
+    protected final int maxLineLength;
+    protected final boolean renderBorder;
 
 }
-

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/SkyblockItemGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/SkyblockItemGenerator.java
@@ -1,0 +1,250 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock;
+
+import com.google.gson.JsonObject;
+import lombok.extern.log4j.Log4j2;
+import net.hypixel.nerdbot.command.GeneratorCommands;
+import net.hypixel.nerdbot.generator.builder.ClassBuilder;
+import net.hypixel.nerdbot.generator.data.Rarity;
+import net.hypixel.nerdbot.generator.exception.GeneratorException;
+import net.hypixel.nerdbot.generator.image.MinecraftTooltip;
+import net.hypixel.nerdbot.generator.impl.tooltip.MinecraftTooltipGenerator;
+import net.hypixel.nerdbot.generator.item.GeneratedObject;
+import net.hypixel.nerdbot.generator.text.ChatFormat;
+import net.hypixel.nerdbot.generator.text.segment.LineSegment;
+import net.hypixel.nerdbot.generator.text.wrapper.TextWrapper;
+import net.hypixel.nerdbot.util.Range;
+import net.hypixel.nerdbot.util.Util;
+import org.apache.commons.lang.StringUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+@Log4j2
+public class SkyblockItemGenerator extends MinecraftTooltipGenerator<SkyblockItemSettings> {
+
+    protected final Rarity rarity;
+    protected final String type;
+    protected final boolean emptyLine;
+    protected final boolean normalItem;
+
+    protected SkyblockItemGenerator(String name, Rarity rarity, String itemLore, String type, boolean emptyLine, int alpha, int padding, boolean normalItem, boolean centeredText, int maxLineLength, boolean renderBorder) {
+        super(
+            name,
+            renderBorder,
+            maxLineLength,
+            padding,
+            alpha,
+            itemLore,
+            centeredText
+        );
+        this.rarity = rarity;
+        this.type = type;
+        this.emptyLine = emptyLine;
+        this.normalItem = normalItem;
+    }
+
+    @Override
+    public GeneratedObject generate() {
+        SkyblockItemSettings settings = new SkyblockItemSettings(
+            itemLore,
+            name,
+            alpha,
+            padding,
+            maxLineLength,
+            renderBorder,
+            rarity,
+            emptyLine,
+            type,
+            normalItem
+        );
+
+        return new GeneratedObject(buildItem(settings));
+    }
+
+    @Override
+    public MinecraftTooltip parseLore(SkyblockItemSettings settings) {
+        log.debug("Parsing lore for item: {} with SkyblockItemSettings: {}", settings.getName(), settings);
+
+        MinecraftTooltip.Builder builder = MinecraftTooltip.builder()
+            .withPadding(settings.getPadding())
+            .isPaddingFirstLine(settings.isNormalItem())
+            .setRenderBorder(settings.isRenderBorder())
+            .withAlpha(Range.between(0, 255).fit(settings.getAlpha()));
+
+        if (settings.getName() != null && !settings.getName().isEmpty()) {
+            String name = settings.getName();
+
+            if (rarity != null && rarity != Rarity.byName("NONE")) {
+                name = rarity.getColorCode() + name;
+            }
+
+            builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(name), '&'));
+        }
+
+        List<List<LineSegment>> segments = new ArrayList<>();
+
+        for (String line : TextWrapper.wrapString(settings.getLore(), settings.getMaxLineLength())) {
+            segments.add(LineSegment.fromLegacy(line, '&'));
+        }
+
+        for (List<LineSegment> line : segments) {
+            builder.withLines(line);
+        }
+
+        if (rarity != null && rarity != Rarity.byName("NONE")) {
+            if (settings.isEmptyLine()) {
+                builder.withEmptyLine();
+            }
+            builder.withLines(LineSegment.fromLegacy(rarity.getFormattedDisplay() + " " + settings.getType(), '&'));
+        }
+
+        return builder.build();
+    }
+
+    public static class Builder implements ClassBuilder<SkyblockItemGenerator> {
+        private String name;
+        private Rarity rarity;
+        private String itemLore;
+        private String type;
+        private Boolean emptyLine;
+        private Integer alpha;
+        private Integer padding;
+        private boolean paddingFirstLine;
+        private int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
+        private transient boolean bypassMaxLineLength;
+        private boolean centered;
+        private transient boolean renderBorder;
+
+        public SkyblockItemGenerator.Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withRarity(Rarity rarity) {
+            this.rarity = rarity;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withItemLore(String itemLore) {
+            this.itemLore = itemLore;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withEmptyLine(boolean emptyLine) {
+            this.emptyLine = emptyLine;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withAlpha(int alpha) {
+            this.alpha = alpha;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withPadding(int padding) {
+            this.padding = padding;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder isPaddingFirstLine(boolean paddingFirstLine) {
+            this.paddingFirstLine = paddingFirstLine;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder isTextCentered(boolean centered) {
+            this.centered = centered;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withMaxLineLength(int maxLineLength) {
+            if (bypassMaxLineLength) {
+                this.maxLineLength = maxLineLength;
+            } else {
+                this.maxLineLength = MinecraftTooltip.LINE_LENGTH.fit(maxLineLength);
+            }
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder bypassMaxLineLength(boolean bypassMaxLineLength) {
+            this.bypassMaxLineLength = bypassMaxLineLength;
+            return this;
+        }
+
+        public SkyblockItemGenerator.Builder withRenderBorder(boolean renderBorder) {
+            this.renderBorder = renderBorder;
+            return this;
+        }
+
+        // TODO support components
+        public SkyblockItemGenerator.Builder parseNbtJson(JsonObject nbtJson) {
+            this.emptyLine = false;
+            this.paddingFirstLine = false;
+            this.centered = false;
+            this.rarity = Rarity.byName("NONE");
+            this.itemLore = "";
+
+            JsonObject tagObject = nbtJson.get("tag").getAsJsonObject();
+            JsonObject displayObject = tagObject.get("display").getAsJsonObject();
+            this.name = displayObject.getAsJsonObject().get("Name").getAsString();
+
+            displayObject.getAsJsonObject().get("Lore").getAsJsonArray().forEach(jsonElement -> {
+                this.itemLore += jsonElement.getAsString() + "\\n";
+            });
+
+            this.itemLore = this.itemLore.replaceAll(String.valueOf(ChatFormat.SECTION_SYMBOL), String.valueOf(ChatFormat.AMPERSAND_SYMBOL));
+
+            return this;
+        }
+
+        /**
+         * Builds a slash command from the current state of the builder.
+         *
+         * @return A properly formatted slash command string.
+         */
+        public String buildSlashCommand() {
+            StringBuilder commandBuilder = new StringBuilder("/" + GeneratorCommands.BASE_COMMAND + " item full ");
+            Field[] fields = this.getClass().getDeclaredFields();
+
+            for (Field field : fields) {
+                try {
+                    field.setAccessible(true);
+
+                    int modifiers = field.getModifiers();
+                    if (Modifier.isTransient(modifiers)) {
+                        continue;
+                    }
+
+                    Object value = field.get(this);
+                    if (value != null && !(value instanceof String string && string.isEmpty())) {
+                        String paramName = Util.convertCamelCaseToSnakeCase(field.getName());
+
+                        commandBuilder.append(paramName).append(": ");
+
+                        if (value instanceof Boolean bool) {
+                            commandBuilder.append(StringUtils.capitalize(bool.toString())); // Discord slash commands use "True" and "False" for booleans
+                        } else {
+                            commandBuilder.append(value);
+                        }
+
+                        commandBuilder.append(" ");
+                    }
+                } catch (IllegalAccessException e) {
+                    throw new GeneratorException("Failed to build slash command", e);
+                }
+            }
+
+            return commandBuilder.toString().trim();
+        }
+
+        @Override
+        public SkyblockItemGenerator build() {
+            return new SkyblockItemGenerator(name, rarity, itemLore, type, emptyLine, alpha, padding, paddingFirstLine, centered, maxLineLength, renderBorder);
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/SkyblockItemSettings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/SkyblockItemSettings.java
@@ -1,0 +1,25 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock;
+
+import lombok.Getter;
+import lombok.ToString;
+import net.hypixel.nerdbot.generator.data.Rarity;
+import net.hypixel.nerdbot.generator.impl.tooltip.TooltipSettings;
+
+@Getter
+@ToString
+public class SkyblockItemSettings extends TooltipSettings {
+
+    private final Rarity rarity;
+    private final boolean emptyLine;
+    private final String type;
+    private final boolean normalItem;
+
+    public SkyblockItemSettings (String lore, String name, int alpha, int padding, int maxLineLength, boolean renderBorder, Rarity rarity, boolean emptyLine, String type, boolean normalItem) {
+        super(lore, name, alpha, padding, maxLineLength, renderBorder);
+
+        this.rarity = rarity;
+        this.emptyLine = emptyLine;
+        this.type = type;
+        this.normalItem = normalItem;
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerGenerator.java
@@ -1,0 +1,226 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock.powerstone;
+
+import lombok.extern.log4j.Log4j2;
+import net.hypixel.nerdbot.command.GeneratorCommands;
+import net.hypixel.nerdbot.generator.builder.ClassBuilder;
+import net.hypixel.nerdbot.generator.data.PowerStrength;
+import net.hypixel.nerdbot.generator.image.MinecraftTooltip;
+import net.hypixel.nerdbot.generator.impl.tooltip.MinecraftTooltipGenerator;
+import net.hypixel.nerdbot.generator.item.GeneratedObject;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneStat;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneUtil;
+import net.hypixel.nerdbot.generator.powerstone.ScalingPowerstoneStat;
+import net.hypixel.nerdbot.generator.text.segment.LineSegment;
+import net.hypixel.nerdbot.generator.text.wrapper.TextWrapper;
+import net.hypixel.nerdbot.util.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Log4j2
+public class SkyblockPowerGenerator extends MinecraftTooltipGenerator<SkyblockPowerSettings> {
+
+    private final PowerStrength strength;
+    private final List<ScalingPowerstoneStat> scalingStats;
+    private final List<PowerstoneStat> staticStats;
+    private final boolean selected;
+    private final int magicalPower;
+    private final boolean stonePower;
+
+    protected SkyblockPowerGenerator(String name, boolean renderBorder, int maxLineLength, int padding, int alpha, boolean centeredText, PowerStrength strength, List<ScalingPowerstoneStat> scalingStats, List<PowerstoneStat> staticStats, boolean selected, int magicalPower, boolean stonePower) {
+        super(name, renderBorder, maxLineLength, padding, alpha, "", centeredText);
+        this.strength = strength;
+        this.scalingStats = scalingStats;
+        this.staticStats = staticStats;
+        this.selected = selected;
+        this.magicalPower = magicalPower;
+        this.stonePower = stonePower;
+    }
+
+    @Override
+    public GeneratedObject generate() {
+        SkyblockPowerSettings settings = new SkyblockPowerSettings(
+            itemLore,
+            name,
+            alpha,
+            padding,
+            maxLineLength,
+            renderBorder,
+            strength,
+            scalingStats,
+            staticStats,
+            selected,
+            magicalPower,
+            stonePower
+        );
+
+        return new GeneratedObject(buildItem(settings));
+    }
+
+    @Override
+    public MinecraftTooltip parseLore(SkyblockPowerSettings settings) {
+        log.debug("Parsing lore for item: {} with SkyblockPowerSettings: {}", settings.getName(), settings);
+
+        MinecraftTooltip.Builder builder = MinecraftTooltip.builder()
+            .withPadding(settings.getPadding())
+            .setRenderBorder(settings.isRenderBorder())
+            .withAlpha(Range.between(0, 255).fit(settings.getAlpha()));
+
+        if (settings.getName() != null && !settings.getName().isEmpty()) {
+            String name = "&a" + settings.getName();
+
+            builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(name), '&'));
+        }
+
+        builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                "&r&8" +
+                        strength.getFormattedDisplay()),
+                '&'
+        ));
+
+        if (settings.getScalingStats() != null && !settings.getScalingStats().isEmpty()) {
+            builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                    "\\n" +
+                            PowerstoneUtil.SCALING_STATS_HEADER_POWER +
+                            PowerstoneUtil.parseScalingStatsToString(settings.getScalingStats())),
+                    '&'
+            ));
+        }
+
+        if (settings.getStaticStats() != null && !settings.getStaticStats().isEmpty()) {
+            builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                    "\\n" +
+                            PowerstoneUtil.STATIC_STATS_HEADER +
+                            PowerstoneUtil.parseStaticStatsToString(settings.getStaticStats())),
+                    '&'
+            ));
+        }
+
+        builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                "\\n" +
+                        PowerstoneUtil.MAGICAL_POWER_FORMAT.formatted(settings.getMagicalPower())),
+                '&'
+        ));
+
+        builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                "\\n" +
+                        (selected ? PowerstoneUtil.POWER_SELECTED_TRUE : PowerstoneUtil.POWER_SELECTED_FALSE)),
+            '&'
+        ));
+
+        return builder.build();
+    }
+
+
+    public static class Builder implements ClassBuilder<SkyblockPowerGenerator> {
+        private String name;
+        private int padding;
+        private int alpha;
+        private PowerStrength strength;
+        private List<ScalingPowerstoneStat> scalingStats = new ArrayList<>();
+        private List<PowerstoneStat> staticStats = new ArrayList<>();
+        private boolean selected;
+        private int magicalPower;
+        private boolean stonePower;
+
+        public SkyblockPowerGenerator.Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withPadding(int padding) {
+            this.padding = padding;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withAlpha(int alpha) {
+            this.alpha = alpha;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withStrength(PowerStrength strength) {
+            this.strength = strength;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withScalingStats(List<ScalingPowerstoneStat> stats) {
+            this.scalingStats.addAll(stats);
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withScalingStat(ScalingPowerstoneStat stat) {
+            this.scalingStats.add(stat);
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withStaticStats(List<PowerstoneStat> stats) {
+            this.staticStats.addAll(stats);
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withStaticStat(PowerstoneStat stat) {
+            this.staticStats.add(stat);
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withSelected(boolean selected) {
+            this.selected = selected;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withMagicalPower(int magicalPower) {
+            this.magicalPower = magicalPower;
+            return this;
+        }
+
+        public SkyblockPowerGenerator.Builder withStonePower(boolean stonePower) {
+            this.stonePower = stonePower;
+            return this;
+        }
+
+        public String buildSlashCommand() {
+            StringBuilder builder =
+                    new StringBuilder(
+                            "/" + GeneratorCommands.BASE_COMMAND + " item full" +
+                            " name:&a" + this.name +
+                            " alpha:" + this.alpha +
+                            " padding:" + this.padding +
+                            " item_lore:&r&8" + strength.getFormattedDisplay()
+                    );
+
+            if (!this.scalingStats.isEmpty()) {
+                builder.append("\\n\\n")
+                        .append(PowerstoneUtil.SCALING_STATS_HEADER_POWER)
+                        .append(PowerstoneUtil.parseScalingStatsToString(this.scalingStats));
+            }
+            else {
+                builder.append("\\n");
+            }
+
+            if (!this.staticStats.isEmpty()) {
+                builder.append("\\n")
+                        .append(PowerstoneUtil.STATIC_STATS_HEADER)
+                        .append(PowerstoneUtil.parseStaticStatsToString(this.staticStats));
+            }
+            else {
+                builder.append("\\n");
+            }
+
+            builder.append("\\n")
+                    .append(PowerstoneUtil.MAGICAL_POWER_FORMAT.formatted(this.magicalPower));
+
+            builder.append("\\n\\n")
+                    .append(this.selected ? PowerstoneUtil.POWER_SELECTED_TRUE : PowerstoneUtil.POWER_SELECTED_FALSE);
+
+            return builder.toString();
+        }
+
+        @Override
+        public SkyblockPowerGenerator build() {
+            boolean renderBorder = true;
+            int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
+            boolean centeredText = false;
+            return new SkyblockPowerGenerator(name, renderBorder, maxLineLength, padding, alpha, centeredText, strength, scalingStats, staticStats, selected, magicalPower, stonePower);
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerGenerator.java
@@ -213,6 +213,10 @@ public class SkyblockPowerGenerator extends MinecraftTooltipGenerator<SkyblockPo
                     .append(this.selected ? PowerstoneUtil.POWER_SELECTED_TRUE : PowerstoneUtil.POWER_SELECTED_FALSE);
 
             return builder.toString();
+            // TODO see below
+            // NOTE: Currently gen full still needs the fields 'rarity' and 'type' and this builder doesn't add those so for now the user still has to add it them themselves.
+            // Why not add them? I already made a PR (https://github.com/SkyBlock-Nerds/NerdBot/pull/340) that removes them, I'm sure that if I do add them now I'm going to forget to remove it so instead adding a to do.
+            // So if you are reading this and the above pr is merged remove these comments please, thank you! -Socks
         }
 
         @Override

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerSettings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerSettings.java
@@ -1,0 +1,30 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock.powerstone;
+
+import lombok.Getter;
+import net.hypixel.nerdbot.generator.data.PowerStrength;
+import net.hypixel.nerdbot.generator.impl.tooltip.TooltipSettings;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneStat;
+import net.hypixel.nerdbot.generator.powerstone.ScalingPowerstoneStat;
+
+import java.util.List;
+
+@Getter
+public class SkyblockPowerSettings extends TooltipSettings {
+
+    private final PowerStrength strength;
+    private final List<ScalingPowerstoneStat> scalingStats;
+    private final List<PowerstoneStat> staticStats;
+    private final boolean selected;
+    private final int magicalPower;
+    private final boolean stonePower;
+
+    public SkyblockPowerSettings(String lore, String name, int alpha, int padding, int maxLineLength, boolean renderBorder, PowerStrength strength, List<ScalingPowerstoneStat> scalingStats, List<PowerstoneStat> staticStats, boolean selected, int magicalPower, boolean stonePower) {
+        super(lore, name, alpha, padding, maxLineLength, renderBorder);
+        this.strength = strength;
+        this.scalingStats = scalingStats;
+        this.staticStats = staticStats;
+        this.selected = selected;
+        this.magicalPower = magicalPower;
+        this.stonePower = stonePower;
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneGenerator.java
@@ -14,7 +14,6 @@ import net.hypixel.nerdbot.generator.powerstone.ScalingPowerstoneStat;
 import net.hypixel.nerdbot.generator.text.segment.LineSegment;
 import net.hypixel.nerdbot.generator.text.wrapper.TextWrapper;
 import net.hypixel.nerdbot.util.Range;
-import org.apache.commons.lang.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneGenerator.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneGenerator.java
@@ -1,0 +1,270 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock.powerstone;
+
+import lombok.extern.log4j.Log4j2;
+import net.hypixel.nerdbot.command.GeneratorCommands;
+import net.hypixel.nerdbot.generator.builder.ClassBuilder;
+import net.hypixel.nerdbot.generator.data.Rarity;
+import net.hypixel.nerdbot.generator.image.MinecraftTooltip;
+import net.hypixel.nerdbot.generator.impl.tooltip.skyblock.SkyblockItemGenerator;
+import net.hypixel.nerdbot.generator.impl.tooltip.skyblock.SkyblockItemSettings;
+import net.hypixel.nerdbot.generator.item.GeneratedObject;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneStat;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneUtil;
+import net.hypixel.nerdbot.generator.powerstone.ScalingPowerstoneStat;
+import net.hypixel.nerdbot.generator.text.segment.LineSegment;
+import net.hypixel.nerdbot.generator.text.wrapper.TextWrapper;
+import net.hypixel.nerdbot.util.Range;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Log4j2
+public class SkyblockPowerstoneGenerator extends SkyblockItemGenerator {
+
+    private final List<ScalingPowerstoneStat> scalingStats;
+    private final List<PowerstoneStat> staticStats;
+    private final int magicalPower;
+    private final String combatRequirement;
+
+    protected SkyblockPowerstoneGenerator(String name, Rarity rarity, String itemLore, String type, boolean emptyLine, int alpha, int padding, boolean normalItem, boolean centeredText, int maxLineLength, boolean renderBorder, List<ScalingPowerstoneStat> scalingStats, List<PowerstoneStat> staticStats, int magicalPower, String combatRequirement) {
+        super(name, rarity, itemLore, type, emptyLine, alpha, padding, normalItem, centeredText, maxLineLength, renderBorder);
+        this.scalingStats = scalingStats;
+        this.staticStats = staticStats;
+        this.magicalPower = magicalPower;
+        this.combatRequirement = combatRequirement;
+    }
+
+    @Override
+    public GeneratedObject generate() {
+        SkyblockPowerstoneSettings settings = new SkyblockPowerstoneSettings(
+            itemLore,
+            name,
+            alpha,
+            padding,
+            maxLineLength,
+            renderBorder,
+            rarity,
+            emptyLine,
+            type,
+            normalItem,
+            scalingStats,
+            staticStats,
+            magicalPower,
+            combatRequirement
+        );
+
+        return new GeneratedObject(buildItem(settings));
+    }
+
+    @Override
+    public MinecraftTooltip parseLore(SkyblockItemSettings settings) {
+        if (settings instanceof SkyblockPowerstoneSettings) {
+            SkyblockPowerstoneSettings powerstoneSettings = (SkyblockPowerstoneSettings) settings;
+
+            MinecraftTooltip.Builder builder = MinecraftTooltip.builder()
+                .withPadding(powerstoneSettings.getPadding())
+                .setRenderBorder(powerstoneSettings.isRenderBorder())
+                .withAlpha(Range.between(0,255).fit(powerstoneSettings.getAlpha()));
+
+            if (settings.getName() != null && !settings.getName().isEmpty()) {
+                String name;
+
+                if (rarity != null && rarity != Rarity.byName("NONE")) {
+                    name = rarity.getColorCode() + settings.getName();
+                }
+                else {
+                     name = settings.getName();
+                }
+
+                builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(name), '&'));
+            }
+
+            List<List<LineSegment>> defaultStoneFormatSegments = new ArrayList<>();
+
+            for (String line : TextWrapper.wrapString(TextWrapper.parseLine(PowerstoneUtil.DEFAULT_STONE_FORMAT.formatted(powerstoneSettings.getName())), settings.getMaxLineLength())) {
+                defaultStoneFormatSegments.add(LineSegment.fromLegacy(line, '&'));
+            }
+
+            for (List<LineSegment> line : defaultStoneFormatSegments) {
+                builder.withLines(line);
+            }
+
+            if (powerstoneSettings.getLore() != null && !powerstoneSettings.getLore().isEmpty()) {
+                List<List<LineSegment>> extraLoreSegments = new ArrayList<>();
+
+                for (String line : TextWrapper.wrapString(TextWrapper.parseLine("\\n" + settings.getLore()), settings.getMaxLineLength())) {
+                    extraLoreSegments.add(LineSegment.fromLegacy(line, '&'));
+                }
+
+                for (List<LineSegment> line : extraLoreSegments) {
+                    builder.withLines(line);
+                }
+            }
+
+            if (powerstoneSettings.getScalingStats() != null && !powerstoneSettings.getScalingStats().isEmpty()) {
+                builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                        new StringBuilder("\\n")
+                            .append(PowerstoneUtil.SCALING_STATS_HEADER_POWERSTONE_FORMAT.formatted(powerstoneSettings.getMagicalPower()))
+                            .append(PowerstoneUtil.parseScalingStatsToString(powerstoneSettings.getScalingStats()))
+                            .toString()),
+                    '&'));
+            }
+
+            if (powerstoneSettings.getStaticStats() != null && !powerstoneSettings.getStaticStats().isEmpty()) {
+                builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                        new StringBuilder("\\n")
+                            .append(PowerstoneUtil.STATIC_STATS_HEADER)
+                            .append(PowerstoneUtil.parseStaticStatsToString(powerstoneSettings.getStaticStats()))
+                            .toString()),
+                    '&'));
+            }
+
+            if (powerstoneSettings.getCombatRequirement() != null && !powerstoneSettings.getCombatRequirement().isEmpty()) {
+                builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                    new StringBuilder("\\n")
+                        .append(PowerstoneUtil.COMBAT_REQUIREMENT_POWERSTONE_FORMAT.formatted(powerstoneSettings.getCombatRequirement()))
+                        .toString()),
+                    '&'
+                ));
+            }
+
+            if (powerstoneSettings.getRarity() != null && powerstoneSettings.getRarity() != Rarity.byName("NONE")) {
+                builder.withLines(LineSegment.fromLegacy(TextWrapper.parseLine(
+                        new StringBuilder("\\n")
+                                .append(rarity.getFormattedDisplay())
+                                .append(" ")
+                                .append(powerstoneSettings.getType())
+                                .toString()),
+                        '&'
+                ));
+            }
+
+            return builder.build();
+        }
+        else {
+            throw new ClassCastException("Couldn't parse lore due to invalid settings object being passed. Expected SkyblockPowerstoneSettings but got:" + settings);
+        }
+    }
+
+    public static class Builder implements ClassBuilder<SkyblockPowerstoneGenerator> {
+        private String name;
+        private Rarity rarity;
+        private String extraLore;
+        private int alpha;
+        private int padding;
+        private List<ScalingPowerstoneStat> scalingStats = new ArrayList<>();
+        private List<PowerstoneStat> staticStats = new ArrayList<>();
+        private int magicalPower;
+        private String combatRequirement;
+
+        public SkyblockPowerstoneGenerator.Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withRarity(Rarity rarity) {
+            this.rarity = rarity;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withExtraLore(String extraLore) {
+            this.extraLore = extraLore;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withAlpha(int alpha) {
+            this.alpha = alpha;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withPadding(int padding) {
+            this.padding = padding;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withScalingStats(List<ScalingPowerstoneStat> stats) {
+            this.scalingStats.addAll(stats);
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withScalingStat(ScalingPowerstoneStat stat) {
+            this.scalingStats.add(stat);
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withStaticStats(List<PowerstoneStat> stats) {
+            this.staticStats.addAll(stats);
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withStaticStat(PowerstoneStat stat) {
+            this.staticStats.add(stat);
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withMagicalPower(int magicalPower) {
+            this.magicalPower = magicalPower;
+            return this;
+        }
+
+        public SkyblockPowerstoneGenerator.Builder withCombatRequirement(String combatRequirement) {
+            this.combatRequirement = combatRequirement;
+            return this;
+        }
+
+        public String buildSlashCommand() {
+            StringBuilder builder =
+                    new StringBuilder(
+                            "/" + GeneratorCommands.BASE_COMMAND + " item full" +
+                            " name:" + this.name +
+                            " rarity:" + this.rarity.getName() +
+                            " type:" + PowerstoneUtil.POWER_STONE_ITEM_TYPE +
+                            " alpha:" + this.alpha +
+                            " padding:" + this.padding +
+                            " item_lore:" + PowerstoneUtil.DEFAULT_STONE_FORMAT.formatted(this.name)
+                    );
+
+            if (this.extraLore != null) {
+                builder.append("\\n\\n")
+                        .append(extraLore);
+            }
+
+            if (!this.scalingStats.isEmpty()) {
+                builder.append("\\n\\n")
+                        .append(PowerstoneUtil.SCALING_STATS_HEADER_POWERSTONE_FORMAT.formatted(this.magicalPower))
+                        .append(PowerstoneUtil.parseScalingStatsToString(this.scalingStats));
+            }
+            else {
+                builder.append("\\n");
+            }
+
+            if (!this.staticStats.isEmpty()) {
+                builder.append("\\n")
+                        .append(PowerstoneUtil.STATIC_STATS_HEADER)
+                        .append(PowerstoneUtil.parseStaticStatsToString(this.staticStats));
+            }
+            else {
+                builder.append("\\n");
+            }
+
+            if (this.combatRequirement != null) {
+                builder.append("\\n")
+                        .append(PowerstoneUtil.COMBAT_REQUIREMENT_POWERSTONE_FORMAT.formatted(this.combatRequirement));
+            }
+
+            return builder.toString();
+        }
+
+        @Override
+        public SkyblockPowerstoneGenerator build() {
+            String type = PowerstoneUtil.POWER_STONE_ITEM_TYPE;
+            boolean emptyLine = false;
+            boolean normalItem = true;
+            boolean centeredText = false;
+            int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
+            boolean renderBorder = true;
+            return new SkyblockPowerstoneGenerator(name, rarity, extraLore, type, emptyLine, alpha, padding, normalItem, centeredText, maxLineLength, renderBorder, scalingStats, staticStats, magicalPower, combatRequirement);
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneSettings.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/impl/tooltip/skyblock/powerstone/SkyblockPowerstoneSettings.java
@@ -1,0 +1,26 @@
+package net.hypixel.nerdbot.generator.impl.tooltip.skyblock.powerstone;
+
+import lombok.Getter;
+import net.hypixel.nerdbot.generator.data.Rarity;
+import net.hypixel.nerdbot.generator.impl.tooltip.skyblock.SkyblockItemSettings;
+import net.hypixel.nerdbot.generator.powerstone.PowerstoneStat;
+import net.hypixel.nerdbot.generator.powerstone.ScalingPowerstoneStat;
+
+import java.util.List;
+
+@Getter
+public class SkyblockPowerstoneSettings extends SkyblockItemSettings {
+
+    private final List<ScalingPowerstoneStat> scalingStats;
+    private final List<PowerstoneStat> staticStats;
+    private final int magicalPower;
+    private final String combatRequirement;
+
+    public SkyblockPowerstoneSettings(String lore, String name, int alpha, int padding, int maxLineLength, boolean renderBorder, Rarity rarity, boolean emptyLine, String type, boolean paddingFirstLine, List<ScalingPowerstoneStat> scalingStats, List<PowerstoneStat> staticStats, int magicalPower, String combatRequirement) {
+        super(lore, name, alpha, padding, maxLineLength, renderBorder, rarity, emptyLine, type, paddingFirstLine);
+        this.scalingStats = scalingStats;
+        this.staticStats = staticStats;
+        this.magicalPower = magicalPower;
+        this.combatRequirement = combatRequirement;
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/InvalidPowerstoneStatFormatException.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/InvalidPowerstoneStatFormatException.java
@@ -1,0 +1,8 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+public class InvalidPowerstoneStatFormatException extends RuntimeException {
+
+    public InvalidPowerstoneStatFormatException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/Powerstone.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/Powerstone.java
@@ -1,0 +1,23 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import net.hypixel.nerdbot.generator.builder.ClassBuilder;
+import net.hypixel.nerdbot.util.Tuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Powerstone {
+    List<PowerstoneStats> scalingStats = new ArrayList<PowerstoneStats>();
+    List<PowerstoneStats> staticStats = new ArrayList<PowerstoneStats>();
+
+    public static class Builder implements ClassBuilder<Powerstone> {
+
+        @Override
+        public Powerstone build() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/Powerstone.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/Powerstone.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Powerstone {
+
     List<PowerstoneStats> scalingStats = new ArrayList<PowerstoneStats>();
     List<PowerstoneStats> staticStats = new ArrayList<PowerstoneStats>();
 

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStat.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStat.java
@@ -1,0 +1,74 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.hypixel.nerdbot.generator.data.Stat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PowerstoneStat {
+
+    protected final Stat stat;
+    protected final int statValue;
+
+    /**
+     * Creates a {@link List} of {@link PowerstoneStat} from a properly formatted string.
+     *
+     * @param stats Formatted string: {@link String `statName1:statValue1,statName2:statValue2`}.
+     *
+     * @return A {@link List} of {@link PowerstoneStat}.
+     *
+     * @throws InvalidPowerstoneStatFormatException If the format in the {@link String stats} param isn't correct.
+     */
+    public static List<PowerstoneStat> statsFromString(String stats) {
+        List<PowerstoneStat> statsList = new ArrayList<>();
+
+        if (stats != null) {
+            String[] entries = stats.split(",");
+
+            for (String entry : entries) {
+                statsList.add(statFromString(entry));
+            }
+        }
+
+        return statsList;
+    }
+
+    /**
+     * Creates a {@link PowerstoneStat} from a properly formatted string.
+     *
+     * @param stat Formatted string: {@link String `statName:statValue`}.
+     *
+     * @return A {@link PowerstoneStat}.
+     *
+     * @throws InvalidPowerstoneStatFormatException If the format in the {@link String stat} param isn't correct.
+     */
+    public static PowerstoneStat statFromString(String stat) {
+
+        String[] statSplit = stat.split(":");
+
+        if (statSplit.length != 2 || statSplit[0].trim().isEmpty() || statSplit[1].trim().isEmpty()) {
+            throw new InvalidPowerstoneStatFormatException("Stat `" + stat + "` is using an invalid format");
+        }
+
+        String statName = statSplit[0].trim();
+
+        int statValue;
+
+        try {
+            statValue = Integer.parseInt(statSplit[1].trim());
+        } catch (NumberFormatException e) {
+            throw new InvalidPowerstoneStatFormatException("Invalid number for stat `" + statName + "`: " + statSplit[1].trim());
+        }
+
+        return new PowerstoneStat(Stat.byName(statName), statValue);
+    }
+
+    @Override
+    public String toString() {
+        return "%%" + stat.getName() + ":" + statValue + "%%";
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStats.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStats.java
@@ -1,0 +1,11 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+public class PowerstoneStats {
+    String statName;
+    final Integer statValue;
+
+    PowerstoneStats(String statName, Integer statValue) {
+        this.statName = statName;
+        this.statValue = statValue;
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStats.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneStats.java
@@ -1,6 +1,7 @@
 package net.hypixel.nerdbot.generator.powerstone;
 
 public class PowerstoneStats {
+
     String statName;
     final Integer statValue;
 

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneUtil.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneUtil.java
@@ -24,7 +24,7 @@ public class PowerstoneUtil {
         return output.toString();
     }
 
-    public static String parseStaticStatsToString(List<PowerstoneStat> stats){
+    public static String parseStaticStatsToString(List<PowerstoneStat> stats) {
         StringBuilder output = new StringBuilder();
 
         stats.forEach(stat -> output.append('&').append(stat.getStat().getColor().getCode()).append(stat.statValue > 0 ? "+" : "").append(stat).append("\\n"));

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneUtil.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/PowerstoneUtil.java
@@ -1,0 +1,34 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+import java.util.List;
+
+public class PowerstoneUtil {
+
+    public static final String SCALING_STATS_HEADER_POWER = "&rStats:\\n";
+    public static final String SCALING_STATS_HEADER_POWERSTONE_FORMAT = "&rAt &6%d Magical Power&7:\\n"; // %d = Magical power amount
+    public static final String STATIC_STATS_HEADER = "&rUnique Power Bonus:\\n";
+    public static final String MAGICAL_POWER_FORMAT = "&rYou have: &6%d Magical Power"; // %d = Magical power amount
+    public static final String POWER_SELECTED_TRUE = "&r&aPower is selected!";
+    public static final String POWER_SELECTED_FALSE = "&r&eClick to select power!";
+    public static final String COMBAT_REQUIREMENT_POWERSTONE_FORMAT = "&rRequires &aCombat Skill Level %s&7!";
+    public static final String POWER_STONE_ITEM_TYPE = "POWER STONE";
+    public static final String DEFAULT_STONE_FORMAT =
+        "&r&8Power Stone\\n" +
+        "&r&7Combine &a9x &7of this stone at the &6Thaumaturgist &7to permanently unlock the &a%s &7power."; // %s = Powerstone name
+
+    public static String parseScalingStatsToString(List<ScalingPowerstoneStat> stats) {
+        StringBuilder output = new StringBuilder();
+
+        stats.forEach(stat -> output.append('&').append(stat.getStat().getColor().getCode()).append(stat.statValue > 0 ? "+" : "").append(stat).append("\\n"));
+
+        return output.toString();
+    }
+
+    public static String parseStaticStatsToString(List<PowerstoneStat> stats){
+        StringBuilder output = new StringBuilder();
+
+        stats.forEach(stat -> output.append('&').append(stat.getStat().getColor().getCode()).append(stat.statValue > 0 ? "+" : "").append(stat).append("\\n"));
+
+        return output.toString();
+    }
+}

--- a/src/main/java/net/hypixel/nerdbot/generator/powerstone/ScalingPowerstoneStat.java
+++ b/src/main/java/net/hypixel/nerdbot/generator/powerstone/ScalingPowerstoneStat.java
@@ -1,0 +1,71 @@
+package net.hypixel.nerdbot.generator.powerstone;
+
+import lombok.Getter;
+import net.hypixel.nerdbot.generator.data.Stat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ScalingPowerstoneStat extends PowerstoneStat {
+
+    private final Integer basePower;
+
+    public ScalingPowerstoneStat(int basePower, Stat stat, int magicalPower) {
+        super(
+            stat,
+            (int)calculateScalingPowerStoneStat(stat, basePower, magicalPower)
+        );
+        this.basePower = basePower;
+    }
+
+    /**
+     * Creates a {@link ScalingPowerstoneStat} from a properly formatted string (and Magical Power).
+     *
+     * @param string        Formatted string: {@link String `statName:basePower`}.
+     * @param magicalPower  The Magical Power the stats will be scaled with.
+     *
+     * @return              A {@link ScalingPowerstoneStat} with the scaled StatValue.
+     */
+    public static ScalingPowerstoneStat scalingStatfromString(String string, int magicalPower) {
+        PowerstoneStat nonScaledStat = PowerstoneStat.statFromString(string);
+
+        return new ScalingPowerstoneStat(nonScaledStat.getStatValue(), nonScaledStat.getStat(), magicalPower);
+    }
+
+    /**
+     * Creates a {@link List} of {@link ScalingPowerstoneStat} from a properly formatted string (and Magical Power).
+     *
+     * @param stats         Formatted string: {@link String `statName1:statValue1,statName2:statValue2`}.
+     * @param magicalPower  The Magical Power the stats will be scaled with.
+     *
+     * @return              A {@link ScalingPowerstoneStat} with the scaled StatValue.
+     */
+    public static List<ScalingPowerstoneStat> scalingStatsfromString(String stats, int magicalPower) {
+        List<ScalingPowerstoneStat> statsList = new ArrayList<ScalingPowerstoneStat>();
+
+        if (stats != null) {
+            String[] entries = stats.split(",");
+
+            for (String entry : entries) {
+                statsList.add(scalingStatfromString(entry, magicalPower));
+            }
+        }
+
+        return statsList;
+    }
+
+    /**
+     * Calculates the stat value for a scaling Power Stone stat based on the base power and magical power.
+     *
+     * @param stat         The {@link Stat} to calculate the value for
+     * @param basePower    The base power of the stat
+     * @param magicalPower The magical power of the Power Stone
+     *
+     * @return The calculated stat value
+     */
+    public static double calculateScalingPowerStoneStat(Stat stat, int basePower, int magicalPower) {
+        double statMultiplier = stat.getPowerScalingMultiplier() != null ? stat.getPowerScalingMultiplier() : 1;
+        return ((double) basePower / 100) * statMultiplier * 719.28 * Math.pow(Math.log(1 + (0.0019 * magicalPower)), 1.2);
+    }
+}


### PR DESCRIPTION
Small tooltip generator rewrite to allow for easier specific item creation like powerstones.
Added `gen(2) powerstone stone`, Example:
![gen stone example](https://github.com/user-attachments/assets/9c699c22-3c23-44a4-84ae-0cd10477dbb8)
Redid `gen(2) powerstone power`, Example:
![gen power example](https://github.com/user-attachments/assets/26c47c21-2810-40be-acc9-c8d59183ac1f)
