### PR TITLE
Changed ENV vars into ARG vars (in dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=builder /app/${SOURCE_CODE_DIR}/target/${JAR_FILE_NAME} .
 RUN rm -rf ${SOURCE_CODE_DIR}
 
 # Run the application
-ENTRYPOINT exec java ${JAVA_OPTS} -jar ${JAR_FILE_NAME}
+ENTRYPOINT exec java ${JAVA_OPTS} -jar ${JAR_FILE_NAME_ENV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ WORKDIR /app
 # Arguments for Git repository information
 ARG GITHUB_USERNAME
 ARG GITHUB_TOKEN
-ENV REPO_USERNAME=SkyBlock-Nerds
-ENV REPO_NAME=NerdBot
-ENV REPO_BRANCH=master
-ENV SOURCE_CODE_DIR=repository
-ENV JAR_FILE_NAME=NerdBot.jar
+ARG REPO_USERNAME=SkyBlock-Nerds
+ARG REPO_NAME=NerdBot
+ARG REPO_BRANCH=master
+ARG SOURCE_CODE_DIR=repository
+ARG JAR_FILE_NAME=NerdBot.jar
 
 # Clone the Git repository
 RUN apt-get update && apt-get install -y maven git zip unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG REPO_NAME=NerdBot
 ARG REPO_BRANCH=master
 ARG SOURCE_CODE_DIR=repository
 ARG JAR_FILE_NAME=NerdBot.jar
+ENV JAR_FILE_NAME_ENV=$JAR_FILE_NAME
 
 # Clone the Git repository
 RUN apt-get update && apt-get install -y maven git zip unzip \


### PR DESCRIPTION
ENV vars can't be overriden but ARG vars can. Aka right now if you would pass any of the ENV vars in docker build cmd it wouldn't actually do anything with them.

Also do we really need the JAR_FILE_NAME variable because I don't understand why that would ever change. If you still want to have it in a var I could change it back to ENV and edit the contributing.md to not include it.