### PR TITLE
Docker File Redo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,27 +8,13 @@
 - Optional: [Docker](https://www.docker.com/)
 
 ## With Docker
-
-### Environment Variables/Arguments
-
-- `GITHUB_USERNAME` - Your GitHub username
-- `GITHUB_TOKEN` - Your GitHub token
-- `REPO_USERNAME` - The username of the repository owner (default: SkyBlock-Nerds)
-- `REPO_NAME` - The name of the repository (default: NerdBot)
-- `REPO_BRANCH` - The branch of the repository to clone (default: master)
-- `SOURCE_CODE_DIR` - The directory to clone the repository into (default: repository)
-- `JAR_FILE_NAME` - The name of the jar file to build (default: NerdBot.jar)
-
 A Dockerfile is provided to build the bot into a Docker image. To build the image, run the following command:
 
-`docker build -t nerd-bot --build-arg GITHUB_USERNAME=<your-github-username> --build-arg GITHUB_TOKEN=<your-github-token> <...other arguments> .`
+`docker build -t nerd-bot.`
 
 Replace `<your-github-username>` with your GitHub username and `<your-github-token>` with your GitHub token. If you do
 not specify a GitHub username or GitHub token then it will default to cloning the repository with no credentials. You
 can also replace `<...other arguments>` with any of the other arguments listed above.
-
-Every time this image is built, it will automatically pull the latest changes from the repository and compile
-application.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:24-jdk-alpine
 WORKDIR /app
 
 # Copy the built JAR file from the builder stage
-COPY --from=builder /app/target/*.jar /app/
+COPY --from=builder /app/target/*.jar /app/NerdBot.jar
 
 # Run the application
 ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar NerdBot.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use OpenJDK 18 as the base image for building
+# Use Eclipse Temurin with Maven as the builder image
 FROM maven:3-eclipse-temurin-17-alpine AS builder
 
 # Set the working directory
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY pom.xml .
 COPY src ./src
 
-# Install Maven, build the project, then clean up
+# Clean Maven cache and build the project with Maven
 RUN mvn clean install -U -f pom.xml \
     && rm -f /app/target/original-*.jar
 
@@ -18,7 +18,7 @@ FROM eclipse-temurin:24-jdk-alpine
 # Set the working directory
 WORKDIR /app
 
-# Copy the built JAR file from the builder image, excluding those prefixed with original-
+# Copy the built JAR file from the builder stage
 COPY --from=builder /app/target/*.jar /app/
 
 # Run the application

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY pom.xml .
 COPY src ./src
 
 # Build the application using Maven
-RUN apt-get update  \
+RUN apt-get update \
     && apt-get install -y maven \
     && mvn clean install -U -f pom.xml \
     && apt-get remove -y maven \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ COPY src ./src
 # Build the application using Maven
 RUN apt-get update  \
     && apt-get install -y maven \
-    && mvn clean install -U -f pom.xml
+    && mvn clean install -U -f pom.xml \
+    && apt-get remove -y maven \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create a new image to run the application
 FROM builder AS runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM openjdk:18-jdk-slim AS builder
 WORKDIR /app
 
 # Copy the local project to the container
-COPY . .
+COPY pom.xml .
+COPY src ./src
 
 # Build the application using Maven
 RUN apt-get update  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use OpenJDK 18 as the base image for building
-FROM openjdk:18-jdk-slim AS builder
+FROM maven:3-eclipse-temurin-17-alpine AS builder
 
 # Set the working directory
 WORKDIR /app
@@ -9,12 +9,7 @@ COPY pom.xml .
 COPY src ./src
 
 # Install Maven, build the project, then clean up
-RUN apt-get update \
-    && apt-get install -y maven \
-    && mvn clean install -U -f pom.xml \
-    && apt-get remove -y maven \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
+RUN mvn clean install -U -f pom.xml \
     && rm -f /app/target/original-*.jar
 
 # Use a minimal eclipse-temurin image for running the bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,25 @@
-# Use OpenJDK 17 as the base image
+# Use OpenJDK 18 as the base image
 FROM openjdk:18-jdk-slim AS builder
 
 # Set the working directory
 WORKDIR /app
 
-# Arguments for Git repository information
-ARG GITHUB_USERNAME
-ARG GITHUB_TOKEN
-ARG REPO_USERNAME=SkyBlock-Nerds
-ARG REPO_NAME=NerdBot
-ARG REPO_BRANCH=master
-ARG SOURCE_CODE_DIR=repository
-ARG JAR_FILE_NAME=NerdBot.jar
-ENV JAR_FILE_NAME_ENV=$JAR_FILE_NAME
-
-# Clone the Git repository
-RUN apt-get update && apt-get install -y maven git zip unzip \
-    && git clone https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${REPO_USERNAME}/${REPO_NAME}.git -b ${REPO_BRANCH} ${SOURCE_CODE_DIR}
-
-# Set the working directory to the Git directory
-WORKDIR /app/${SOURCE_CODE_DIR}
+# Copy the local project to the container
+COPY . .
 
 # Build the application using Maven
-RUN mvn clean install -U -f pom.xml
+RUN apt-get update  \
+    && apt-get install -y maven \
+    && mvn clean install -U -f pom.xml
 
 # Create a new image to run the application
-FROM builder AS runner
+FROM openjdk:18-jdk-slim AS runner
 
 # Set the working directory
 WORKDIR /app
 
 # Copy the built JAR file from the builder image
-COPY --from=builder /app/${SOURCE_CODE_DIR}/target/${JAR_FILE_NAME} .
-
-# Delete the Git directory
-RUN rm -rf ${SOURCE_CODE_DIR}
+COPY --from=builder /app/target/NerdBot.jar .
 
 # Run the application
-ENTRYPOINT exec java ${JAVA_OPTS} -jar ${JAR_FILE_NAME_ENV}
+ENTRYPOINT exec java ${JAVA_OPTS} -jar NerdBot.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update  \
     && mvn clean install -U -f pom.xml
 
 # Create a new image to run the application
-FROM openjdk:18-jdk-slim AS runner
+FROM builder AS runner
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR /app
 COPY --from=builder /app/target/*.jar /app/
 
 # Run the application
-ENTRYPOINT exec java ${JAVA_OPTS} -jar NerdBot.jar
+ENTRYPOINT ["sh", "-c", "exec java ${JAVA_OPTS} -jar NerdBot.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a new image to run the application
-FROM builder AS runner
+FROM openjdk:18-jdk-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ FROM openjdk:18-jdk-slim
 WORKDIR /app
 
 # Copy the built JAR file from the builder image
-COPY --from=builder /app/target/NerdBot.jar .
+COPY --from=builder /app/target/*.jar /app/
+RUN find /app -name "*.jar" ! -name "original-*.jar" -exec mv {} /app/NerdBot.jar \;
 
 # Run the application
 ENTRYPOINT exec java ${JAVA_OPTS} -jar NerdBot.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /app/target/original-*.jar
 
-# Use a minimal OpenJDK image for running the bot
-FROM openjdk:18-jdk-slim
+# Use a minimal eclipse-temurin image for running the bot
+FROM eclipse-temurin:24-jdk-alpine
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# Use OpenJDK 18 as the base image
+# Use OpenJDK 18 as the base image for building
 FROM openjdk:18-jdk-slim AS builder
 
 # Set the working directory
 WORKDIR /app
 
-# Copy the local project to the container
+# Copy the project files
 COPY pom.xml .
 COPY src ./src
 
-# Build the application using Maven
+# Install Maven, build the project, then clean up
 RUN apt-get update \
     && apt-get install -y maven \
     && mvn clean install -U -f pom.xml \
@@ -16,14 +16,16 @@ RUN apt-get update \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a new image to run the application
+# Use a minimal OpenJDK image for running the bot
 FROM openjdk:18-jdk-slim
 
 # Set the working directory
 WORKDIR /app
 
-# Copy the built JAR file from the builder image
+# Copy the built JAR file from the builder image, excluding those prefixed with original-
 COPY --from=builder /app/target/*.jar /app/
+
+# Rename the JAR file, excluding prefixed with original- (aka deleting the non shade jar)
 RUN find /app -name "*.jar" ! -name "original-*.jar" -exec mv {} /app/NerdBot.jar \;
 
 # Run the application

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
     && mvn clean install -U -f pom.xml \
     && apt-get remove -y maven \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /app/target/original-*.jar
 
 # Use a minimal OpenJDK image for running the bot
 FROM openjdk:18-jdk-slim
@@ -24,9 +25,6 @@ WORKDIR /app
 
 # Copy the built JAR file from the builder image, excluding those prefixed with original-
 COPY --from=builder /app/target/*.jar /app/
-
-# Rename the JAR file, excluding prefixed with original- (aka deleting the non shade jar)
-RUN find /app -name "*.jar" ! -name "original-*.jar" -exec mv {} /app/NerdBot.jar \;
 
 # Run the application
 ENTRYPOINT exec java ${JAVA_OPTS} -jar NerdBot.jar


### PR DESCRIPTION
# Features/changes:
- Made the docker file not rely on the git repo 
- No more build args
  - Also means that you don't have to care about versioning of your jar
- Switched from [OpenJDK](https://hub.docker.com/_/openjdk) to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
  - OpenJDK is depracated
  - ET is more lightweight
- Cut down the final image size from 1.9gb to 534mb (aka a 71.8% file size decrease)
  - Mainly done by:
    - Not including unnecessary files from the root
    - More lightweight runner image
- [Exec form](https://docs.docker.com/reference/dockerfile/#shell-and-exec-form) in entrypoint