### PR TITLE
Let the gen commands address items by item model

### DIFF
--- a/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
+++ b/app/src/main/java/net/hypixel/nerdbot/app/command/GeneratorCommands.java
@@ -98,16 +98,20 @@ public class GeneratorCommands {
     private static final String HIDDEN_OUTPUT_DESCRIPTION = "Whether the output should be hidden (sent ephemerally)";
     private static final String DURABILITY_DESCRIPTION = "Item durability percentage (0-100, only shown if less than 100)";
     private static final String COLOR_DESCRIPTION = "The overlay color (e.g., red, blue, #FF0000)";
+    private static final String ITEM_MODEL_DESCRIPTION = "The minecraft:item_model ref to render (e.g. hypixel_skyblock:item/jacob/cactus_knife)";
     private static final String PACK_DESCRIPTION = "The resource pack used to resolve item textures";
     private static final String TOOLTIP_STYLE_DESCRIPTION = "The pack tooltip style to render with (defaults to the rarity's configured style)";
     private static final String ANIMATED_DESCRIPTION = "Whether animated pack textures render as a GIF (False forces a static render)";
+
+    private static final String MINECRAFT_NAMESPACE = "minecraft:";
 
     private static final boolean AUTO_HIDE_ON_ERROR = true;
 
     @SlashCommand(name = BASE_COMMAND, subcommand = "display", description = "Display an item", guildOnly = true)
     public void generateItem(
         SlashCommandInteractionEvent event,
-        @SlashOption(autocompleteId = "item-names", description = ITEM_DESCRIPTION) String itemId,
+        @SlashOption(autocompleteId = "item-names", description = ITEM_DESCRIPTION, required = false) String itemId,
+        @SlashOption(autocompleteId = "item-names", description = ITEM_MODEL_DESCRIPTION, required = false) String itemModel,
         @SlashOption(description = EXTRA_DATA_DESCRIPTION, required = false) String data,
         @SlashOption(autocompleteId = "overlay-colors", description = COLOR_DESCRIPTION, required = false) String color,
         @SlashOption(description = ENCHANTED_DESCRIPTION, required = false) Boolean enchanted,
@@ -134,16 +138,17 @@ public class GeneratorCommands {
         durability = durability == null ? 100 : durability;
 
         try {
+            requireSingleItemAddress(itemId, itemModel);
+            requireAnItemAddress(itemId, itemModel);
             PackId packId = resolvePackOption(pack);
             GeneratorImageBuilder item = new GeneratorImageBuilder().withContext(context);
 
-            if (itemId.equalsIgnoreCase("player_head") && skinValue != null) {
+            if (itemModel == null && itemId.equalsIgnoreCase("player_head") && skinValue != null) {
                 item.addGenerator(new MinecraftPlayerHeadGenerator.Builder()
                     .withSkin(skinValue)
                     .build());
             } else {
-                MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
-                    .withItem(itemId)
+                MinecraftItemGenerator.Builder itemBuilder = addressItem(new MinecraftItemGenerator.Builder(), itemId, itemModel)
                     .withData(data)
                     .withColor(color)
                     .isEnchanted(enchanted)
@@ -618,27 +623,13 @@ public class GeneratorCommands {
         GenerationContext context = DiscordGenerationContext.fromEvent(event, hidden);
 
         try {
-            MinecraftNbtParser.ParsedNbt parsedNbt = MinecraftNbtParser.parse(nbtInput);
             PackId packId = resolvePackOption(pack);
-            GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
+            ParsedRender render = renderParsedNbtWithFallback(SkyBlockNerdsBot.resourcePackService(), nbtInput, packId, context);
 
-            parsedNbt.getGenerators().forEach(generator -> {
-                if (generator instanceof MinecraftTooltipGenerator.Builder tooltipBuilder) {
-                    // Themed before buildSlashCommand below so the emitted command round-trips the
-                    // pack and the rarity-derived tooltip style, reproducing the preview exactly
-                    applyPackTheme(tooltipBuilder, packId, null, tooltipBuilder.getRarity());
-                } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
-                    // The texture's own animation data decides the output, matching the item
-                    // commands' default: an animated pack texture parses into a GIF preview and
-                    // everything else stays static. The emitted command round-trips because the
-                    // animated option defaults on everywhere.
-                    applyItemPack(itemBuilder, packId, true);
-                }
-
-                generatorImageBuilder.addGenerator(generator.build());
-            });
-
-            GeneratedObject generatedObject = generatorImageBuilder.build();
+            MinecraftNbtParser.ParsedNbt parsedNbt = render.parsedNbt();
+            GeneratedObject generatedObject = render.image();
+            ItemModelFallback fallback = render.fallback();
+            String itemModel = parsedNbt.getParsedItemModel();
 
             Optional<ClassBuilder<? extends Generator>> tooltipGenerator = parsedNbt.getGenerators()
                 .stream()
@@ -650,30 +641,28 @@ public class GeneratorCommands {
                 return;
             }
 
-            String slashCommand = ((MinecraftTooltipGenerator.Builder) tooltipGenerator.get()).buildSlashCommand();
-            String commandItemId = parsedNbt.getParsedItemId();
-
-            if (commandItemId != null && !commandItemId.isBlank()) {
-                if (commandItemId.startsWith("minecraft:")) {
-                    commandItemId = commandItemId.substring("minecraft:".length());
-                }
-                slashCommand += " item_id: " + commandItemId;
-            }
-
-            if (parsedNbt.getBase64Texture() != null && !parsedNbt.getBase64Texture().isBlank()) {
-                slashCommand += " skin_value: " + parsedNbt.getBase64Texture();
-            }
-
-            if (parsedNbt.isEnchanted()) {
-                slashCommand += " enchanted: True";
-            }
+            String slashCommand = appendParsedItemOptions(
+                ((MinecraftTooltipGenerator.Builder) tooltipGenerator.get()).buildSlashCommand(),
+                parsedNbt.getParsedItemId(),
+                itemModel,
+                parsedNbt.getBase64Texture(),
+                parsedNbt.isEnchanted()
+            );
 
             // Escape newlines in lore so the slash command is a single line
             slashCommand = slashCommand.replace("\n", "\\n");
 
             String sourceLabel = attachment != null ? "attachment" : "text input";
-            MessageEditBuilder builder = new MessageEditBuilder()
-                .setContent("Your NBT " + sourceLabel + " has been parsed into a slash command:" + System.lineSeparator() + "```" + System.lineSeparator() + slashCommand + "```");
+            String content = "Your NBT " + sourceLabel + " has been parsed into a slash command:"
+                + System.lineSeparator() + "```" + System.lineSeparator() + slashCommand + "```";
+
+            String fallbackNotice = itemModelFallbackNotice(fallback,
+                packId == null ? null : packId.toString(), itemModel, parsedNbt.getParsedItemId());
+            if (fallbackNotice != null) {
+                content += System.lineSeparator() + "-# " + fallbackNotice;
+            }
+
+            MessageEditBuilder builder = new MessageEditBuilder().setContent(content);
 
             builder.setFiles(renderAttachment(generatedObject, "parsed_nbt"));
 
@@ -734,6 +723,7 @@ public class GeneratorCommands {
         @SlashOption(description = TYPE_DESCRIPTION, required = false) String type,
         @SlashOption(autocompleteId = "item-rarities", description = RARITY_DESCRIPTION, required = false) String rarity,
         @SlashOption(autocompleteId = "item-names", description = ITEM_DESCRIPTION, required = false) String itemId,
+        @SlashOption(autocompleteId = "item-names", description = ITEM_MODEL_DESCRIPTION, required = false) String itemModel,
         @SlashOption(autocompleteId = "overlay-colors", description = COLOR_DESCRIPTION, required = false) String color,
         @SlashOption(description = SKIN_VALUE_DESCRIPTION, required = false) String skinValue,
         @SlashOption(description = RECIPE_STRING_DESCRIPTION, required = false) String recipe,
@@ -774,6 +764,7 @@ public class GeneratorCommands {
         durability = durability == null ? 100 : durability;
 
         try {
+            requireSingleItemAddress(itemId, itemModel);
             PackId packId = resolvePackOption(pack);
             Rarity itemRarity = Rarity.byName(rarity);
             GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
@@ -792,8 +783,8 @@ public class GeneratorCommands {
             applyPackTheme(tooltipBuilder, packId, tooltipStyle, itemRarity);
             MinecraftTooltipGenerator tooltipGenerator = tooltipBuilder.build();
 
-            if (itemId != null) {
-                if (itemId.equalsIgnoreCase("player_head")) {
+            if (itemId != null || itemModel != null) {
+                if (itemModel == null && itemId.equalsIgnoreCase("player_head")) {
                     MinecraftPlayerHeadGenerator.Builder generator = new MinecraftPlayerHeadGenerator.Builder()
                         .withScale(-2);
 
@@ -803,8 +794,7 @@ public class GeneratorCommands {
 
                     generatorImageBuilder.addGenerator(generator.build());
                 } else {
-                    MinecraftItemGenerator.Builder itemBuilder = new MinecraftItemGenerator.Builder()
-                        .withItem(itemId)
+                    MinecraftItemGenerator.Builder itemBuilder = addressItem(new MinecraftItemGenerator.Builder(), itemId, itemModel)
                         .withColor(color)
                         .isEnchanted(enchanted);
                     applyItemPack(itemBuilder, packId, animated);
@@ -1066,6 +1056,241 @@ public class GeneratorCommands {
         return slashCommand;
     }
 
+    /**
+     * Appends the options addressing the item a parsed NBT payload rendered. An item carrying a
+     * {@code minecraft:item_model} component is addressed by that model rather than by its item
+     * id, so the emitted command reproduces the preview instead of falling back to whatever base
+     * item the pack happens to sit on (Hypixel ships most custom items on {@code paper}).
+     *
+     * @param slashCommand The tooltip builder's reconstructed command to append onto
+     * @param itemId       The parsed item id, used only when no item model is present
+     * @param itemModel    The {@code minecraft:item_model} component value, or null when absent
+     * @param skinValue    The resolved player head texture, or null when the item is not a head
+     * @param enchanted    Whether the item render was enchanted
+     *
+     * @return The slash command with the item options appended
+     */
+    static String appendParsedItemOptions(String slashCommand, String itemId, String itemModel, String skinValue, boolean enchanted) {
+        if (itemModel != null && !itemModel.isBlank()) {
+            slashCommand += " item_model: " + itemModel;
+        } else if (itemId != null && !itemId.isBlank()) {
+            slashCommand += " item_id: " + stripMinecraftNamespace(itemId);
+        }
+
+        if (skinValue != null && !skinValue.isBlank()) {
+            slashCommand += " skin_value: " + skinValue;
+        }
+
+        if (enchanted) {
+            slashCommand += " enchanted: True";
+        }
+
+        return slashCommand;
+    }
+
+    /**
+     * The item id without its default namespace, so the emitted command matches what the
+     * {@code item_id} option expects. Item model refs keep their namespace: it selects the
+     * asset directory the model is looked up in.
+     */
+    private static String stripMinecraftNamespace(String itemId) {
+        return itemId.startsWith(MINECRAFT_NAMESPACE) ? itemId.substring(MINECRAFT_NAMESPACE.length()) : itemId;
+    }
+
+    /**
+     * Rejects addressing one item both ways at once, mirroring the generator's own
+     * {@code withItem}/{@code withItemModel} validation but failing with a message the user sees
+     * in Discord rather than an IllegalArgumentException stack trace.
+     *
+     * @throws GeneratorException If both options were supplied
+     */
+    static void requireSingleItemAddress(String itemId, String itemModel) {
+        if (itemId != null && !itemId.isBlank() && itemModel != null && !itemModel.isBlank()) {
+            throw new GeneratorException("The item_id and item_model options are mutually exclusive; use one or the other!");
+        }
+    }
+
+    /**
+     * The outcome of rendering a parsed NBT payload: the image, the parse result it came from,
+     * and which stand-in (if any) had to be drawn in place of the addressed item model.
+     */
+    record ParsedRender(GeneratedObject image, MinecraftNbtParser.ParsedNbt parsedNbt, ItemModelFallback fallback) {
+    }
+
+    /**
+     * Parses and renders an NBT payload, degrading gracefully when an addressed item model cannot
+     * be produced.
+     *
+     * <p>Whether an item model can render is only knowable by rendering it: a ref can index
+     * cleanly and still fail (a definition pointing at a model the pack never shipped, for one),
+     * and the bot's pack is routinely older than the items people paste in. So the model is
+     * attempted as addressed, and only a failure triggers the stand-in - the head texture where
+     * the item has one, otherwise the base item the model sits on. A failure with no item model
+     * involved is rethrown untouched: that is a genuine error about the user's input, not a pack
+     * being behind.
+     *
+     * @param packService The pack service backing the render
+     * @param nbtInput    The raw NBT, re-parsed for the retry so builders start clean
+     * @param packId      The resolved pack, or null for vanilla
+     * @param context     The generation context, may be null outside an interaction
+     *
+     * @throws GeneratorException If the render fails for any reason other than an item model the
+     *                            pack cannot produce
+     */
+    static ParsedRender renderParsedNbtWithFallback(ResourcePackService packService, String nbtInput,
+                                                    @Nullable PackId packId, @Nullable GenerationContext context) throws IOException {
+        MinecraftNbtParser.ParsedNbt parsedNbt = MinecraftNbtParser.parse(nbtInput);
+
+        try {
+            return new ParsedRender(renderParsedNbt(packService, parsedNbt, packId, context, ItemModelFallback.NONE),
+                parsedNbt, ItemModelFallback.NONE);
+        } catch (GeneratorException exception) {
+            // PackResolveException extends GeneratorException, so this covers both a pack that
+            // cannot produce the model and a model that resolves to nothing renderable.
+            // Without an item model the stand-in would be the same item-id render that just
+            // failed, so this rethrows rather than burning a second attempt on the same outcome.
+            ItemModelFallback fallback = itemModelFallback(parsedNbt.getParsedItemModel(), parsedNbt.getBase64Texture());
+            if (fallback == ItemModelFallback.NONE) {
+                throw exception;
+            }
+
+            log.info("Could not render item model '{}' from pack '{}', falling back to {}",
+                parsedNbt.getParsedItemModel(), packId, fallback, exception);
+            // Re-parsed rather than re-used: building a generator fills defaults into its builder,
+            // so the retry starts from clean builders instead of half-configured ones.
+            MinecraftNbtParser.ParsedNbt retry = MinecraftNbtParser.parse(nbtInput);
+            return new ParsedRender(renderParsedNbt(packService, retry, packId, context, fallback), retry, fallback);
+        }
+    }
+
+    /**
+     * Renders a parsed NBT payload, substituting the item generator per the given fallback. The
+     * tooltip is themed here rather than at the call site so the emitted slash command round-trips
+     * the pack and rarity-derived style, reproducing the preview exactly.
+     */
+    private static GeneratedObject renderParsedNbt(ResourcePackService packService, MinecraftNbtParser.ParsedNbt parsedNbt,
+                                                   @Nullable PackId packId, @Nullable GenerationContext context,
+                                                   ItemModelFallback fallback) throws IOException {
+        GeneratorImageBuilder generatorImageBuilder = new GeneratorImageBuilder().withContext(context);
+
+        for (ClassBuilder<? extends Generator> generator : parsedNbt.getGenerators()) {
+            if (generator instanceof MinecraftTooltipGenerator.Builder tooltipBuilder) {
+                applyPackTheme(packService, tooltipBuilder, packId, null, tooltipBuilder.getRarity());
+            } else if (generator instanceof MinecraftItemGenerator.Builder itemBuilder) {
+                if (fallback == ItemModelFallback.PLAYER_HEAD) {
+                    generatorImageBuilder.addGenerator(new MinecraftPlayerHeadGenerator.Builder()
+                        .withSkin(parsedNbt.getBase64Texture())
+                        .withScale(-2)
+                        .build());
+                    continue;
+                }
+
+                if (fallback == ItemModelFallback.ITEM_ID) {
+                    // Rebuilt rather than re-pointed: the parsed builder already committed to
+                    // withItemModel, which the generator treats as exclusive with withItem. A dye
+                    // color on the original is lost here, which is acceptable on a render that is
+                    // already a stand-in for the model the pack could not produce.
+                    MinecraftItemGenerator.Builder baseItem = new MinecraftItemGenerator.Builder()
+                        .withItem(parsedNbt.getParsedItemId())
+                        .isEnchanted(parsedNbt.isEnchanted());
+                    applyItemPack(packService, baseItem, packId, true);
+                    generatorImageBuilder.addGenerator(baseItem.build());
+                    continue;
+                }
+
+                // The texture's own animation data decides the output, matching the item commands'
+                // default: an animated pack texture parses into a GIF preview and everything else
+                // stays static. The emitted command round-trips because the animated option
+                // defaults on everywhere.
+                applyItemPack(packService, itemBuilder, packId, true);
+            }
+
+            generatorImageBuilder.addGenerator(generator.build());
+        }
+
+        return generatorImageBuilder.build();
+    }
+
+    /** What a {@code minecraft:item_model} render degrades to when the pack cannot produce it. */
+    enum ItemModelFallback {
+        /** The model resolved (or none was asked for): render it as addressed. */
+        NONE,
+        /** Render the item's player head texture instead. */
+        PLAYER_HEAD,
+        /** Render the base item the model sits on instead. */
+        ITEM_ID
+    }
+
+    /**
+     * Picks what to render after a render failed with an item model addressed. Hypixel commonly
+     * ships an item with both a {@code minecraft:profile} texture (so vanilla clients see a
+     * textured head) and a {@code minecraft:item_model} (so pack clients see the real model), and
+     * the bot's pack is routinely older than the items people paste in. Degrading - to the head
+     * where one exists, otherwise to the base item the model sits on - keeps the tooltip preview
+     * working; the caller pairs it with {@link #itemModelFallbackNotice} so the substitution is
+     * never silent.
+     *
+     * <p>{@link ItemModelFallback#NONE} for an item that was never addressed by model: that
+     * failure has nothing to do with item models and must surface to the user unchanged.
+     *
+     * @param itemModel     The item model ref that was being rendered, or null when addressing by id
+     * @param base64Texture The resolved head texture, or null/blank when the item has none
+     */
+    static ItemModelFallback itemModelFallback(String itemModel, String base64Texture) {
+        if (itemModel == null || itemModel.isBlank()) {
+            return ItemModelFallback.NONE;
+        }
+
+        return base64Texture != null && !base64Texture.isBlank()
+            ? ItemModelFallback.PLAYER_HEAD
+            : ItemModelFallback.ITEM_ID;
+    }
+
+    /**
+     * The line telling the user their preview is not what the NBT actually asked for, so a wrong
+     * looking icon reads as a stale pack rather than a broken generator.
+     *
+     * @return The notice, or null when nothing was substituted
+     */
+    @Nullable
+    static String itemModelFallbackNotice(ItemModelFallback fallback, @Nullable String packId, String itemModel, String itemId) {
+        if (fallback == ItemModelFallback.NONE) {
+            return null;
+        }
+
+        String source = packId == null ? "Vanilla" : "The `" + packId + "` pack";
+        String rendered = fallback == ItemModelFallback.PLAYER_HEAD
+            ? "the item's player head texture"
+            : "the base item `" + stripMinecraftNamespace(itemId) + "`";
+
+        return source + " could not resolve item model `" + itemModel + "`, so " + rendered
+            + " was rendered instead. The pack is likely older than this item.";
+    }
+
+    /**
+     * Rejects a render that names neither an item id nor an item model, for the subcommands whose
+     * whole output is the item. {@code /gen item} does not use this: there, both options are
+     * genuinely optional because the tooltip renders on its own.
+     *
+     * @throws GeneratorException If neither option was supplied
+     */
+    static void requireAnItemAddress(String itemId, String itemModel) {
+        if ((itemId == null || itemId.isBlank()) && (itemModel == null || itemModel.isBlank())) {
+            throw new GeneratorException("Set either the item_id or the item_model option to pick what to render!");
+        }
+    }
+
+    /**
+     * Points an item builder at whichever address the user gave, keeping the two mutually
+     * exclusive builder calls in one place. Callers validate the pair first with
+     * {@link #requireSingleItemAddress(String, String)}.
+     */
+    private static MinecraftItemGenerator.Builder addressItem(MinecraftItemGenerator.Builder builder, String itemId, String itemModel) {
+        return itemModel != null && !itemModel.isBlank()
+            ? builder.withItemModel(itemModel)
+            : builder.withItem(itemId);
+    }
+
     static String buildSingleDialogue(String npcName, String dialogue, boolean abiphone) {
         String[] lines = dialogue.split("\\\\n");
 
@@ -1238,9 +1463,16 @@ public class GeneratorCommands {
      * @param animated Whether to render the pack's animated item textures as a GIF
      */
     private void applyItemPack(MinecraftItemGenerator.Builder builder, PackId packId, boolean animated) {
-        PackRepository packRepository = SkyBlockNerdsBot.resourcePackService().packRepository();
+        applyItemPack(SkyBlockNerdsBot.resourcePackService(), builder, packId, animated);
+    }
+
+    /**
+     * Overload taking the pack service explicitly, so the render path can be exercised against a
+     * fixture pack instead of the bot's global one.
+     */
+    static void applyItemPack(ResourcePackService packService, MinecraftItemGenerator.Builder builder, PackId packId, boolean animated) {
         builder.withPack(packId)
-            .withPackRepository(packRepository)
+            .withPackRepository(packService.packRepository())
             .withAnimatedTextures(animated);
     }
 
@@ -1288,6 +1520,14 @@ public class GeneratorCommands {
     }
 
     private void applyPackTheme(MinecraftTooltipGenerator.Builder builder, PackId packId, String explicitStyle, Rarity rarity) {
+        applyPackTheme(SkyBlockNerdsBot.resourcePackService(), builder, packId, explicitStyle, rarity);
+    }
+
+    /**
+     * Overload taking the pack service explicitly; see
+     * {@link #applyItemPack(ResourcePackService, MinecraftItemGenerator.Builder, PackId, boolean)}.
+     */
+    static void applyPackTheme(ResourcePackService packService, MinecraftTooltipGenerator.Builder builder, PackId packId, String explicitStyle, Rarity rarity) {
         boolean hasExplicitStyle = explicitStyle != null && !explicitStyle.isBlank();
 
         if (packId == null) {
@@ -1297,8 +1537,11 @@ public class GeneratorCommands {
             return;
         }
 
-        ResourcePackService packService = SkyBlockNerdsBot.resourcePackService();
-        builder.withPack(packId);
+        // The repository is injected rather than left to the tooltip generator's global fallback,
+        // so tooltips and item renders always resolve against the same pack state. These coincide
+        // in production, where the service wraps the global repository, but not for a service
+        // built over its own.
+        builder.withPack(packId).withPackRepository(packService.packRepository());
 
         String style = hasExplicitStyle ? explicitStyle.trim() : packService.tooltipStyleFor(packId, rarity);
         if (style != null) {

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ItemModelAddressingTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ItemModelAddressingTest.java
@@ -1,0 +1,98 @@
+package net.hypixel.nerdbot.app.command;
+
+import net.aerh.imagegenerator.exception.GeneratorException;
+import net.hypixel.nerdbot.app.command.GeneratorCommands.ItemModelFallback;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Choosing how an item is addressed: {@code item_id} and {@code item_model} are mutually
+ * exclusive, and a render that fails because the pack cannot produce the addressed item model
+ * degrades to the player head or the base item rather than failing the whole preview.
+ */
+class ItemModelAddressingTest {
+
+    private static final String MODEL = "hypixel_skyblock:item/island_relevant/safari/safari_belt";
+    private static final String SKIN = "0123456789abcdef";
+
+    @Test
+    void rejectsItemIdAndItemModelTogether() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.requireSingleItemAddress("paper", MODEL));
+
+        assertEquals("The item_id and item_model options are mutually exclusive; use one or the other!",
+            exception.getMessage());
+    }
+
+    @Test
+    void acceptsEitherOptionAlone() {
+        GeneratorCommands.requireSingleItemAddress("paper", null);
+        GeneratorCommands.requireSingleItemAddress(null, MODEL);
+        GeneratorCommands.requireSingleItemAddress(null, null);
+    }
+
+    @Test
+    void treatsBlankOptionsAsAbsent() {
+        GeneratorCommands.requireSingleItemAddress("  ", MODEL);
+        GeneratorCommands.requireSingleItemAddress("paper", "  ");
+    }
+
+    @Test
+    void requiresOneOfTheTwoOptionsWhereTheItemIsTheWholeRender() {
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.requireAnItemAddress(null, "  "));
+
+        assertEquals("Set either the item_id or the item_model option to pick what to render!", exception.getMessage());
+        GeneratorCommands.requireAnItemAddress("paper", null);
+        GeneratorCommands.requireAnItemAddress(null, MODEL);
+    }
+
+    @Test
+    void doesNotRetryWhenTheItemWasNeverAddressedByModel() {
+        assertEquals(ItemModelFallback.NONE, GeneratorCommands.itemModelFallback(null, SKIN),
+            "a render failure unrelated to an item model must surface, not silently substitute");
+        assertEquals(ItemModelFallback.NONE, GeneratorCommands.itemModelFallback("  ", SKIN));
+    }
+
+    @Test
+    void retriesAsThePlayerHeadWhenTheItemHasAProfileTexture() {
+        assertEquals(ItemModelFallback.PLAYER_HEAD, GeneratorCommands.itemModelFallback(MODEL, SKIN),
+            "a profile texture is the closest thing to the model the pack could not produce");
+    }
+
+    @Test
+    void retriesAsTheBaseItemWhenThereIsNoHeadTexture() {
+        assertEquals(ItemModelFallback.ITEM_ID, GeneratorCommands.itemModelFallback(MODEL, null),
+            "a pack that cannot produce the model must not stop the tooltip preview from rendering");
+        assertEquals(ItemModelFallback.ITEM_ID, GeneratorCommands.itemModelFallback(MODEL, "  "));
+    }
+
+    @Test
+    void explainsAnItemIdFallbackToTheUser() {
+        assertEquals("The `hypixel:skyblock` pack could not resolve item model `" + MODEL
+                + "`, so the base item `paper` was rendered instead. The pack is likely older than this item.",
+            GeneratorCommands.itemModelFallbackNotice(ItemModelFallback.ITEM_ID, "hypixel:skyblock", MODEL, "minecraft:paper"));
+    }
+
+    @Test
+    void explainsAPlayerHeadFallbackToTheUser() {
+        assertEquals("The `hypixel:skyblock` pack could not resolve item model `" + MODEL
+                + "`, so the item's player head texture was rendered instead. The pack is likely older than this item.",
+            GeneratorCommands.itemModelFallbackNotice(ItemModelFallback.PLAYER_HEAD, "hypixel:skyblock", MODEL, "minecraft:player_head"));
+    }
+
+    @Test
+    void namesVanillaWhenNoPackWasSelected() {
+        assertEquals("Vanilla could not resolve item model `" + MODEL
+                + "`, so the base item `paper` was rendered instead. The pack is likely older than this item.",
+            GeneratorCommands.itemModelFallbackNotice(ItemModelFallback.ITEM_ID, null, MODEL, "paper"));
+    }
+
+    @Test
+    void saysNothingWhenNothingWasSubstituted() {
+        assertNull(GeneratorCommands.itemModelFallbackNotice(ItemModelFallback.NONE, "hypixel:skyblock", MODEL, "paper"));
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ParsedNbtCommandStringTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ParsedNbtCommandStringTest.java
@@ -1,0 +1,54 @@
+package net.hypixel.nerdbot.app.command;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Building the shareable {@code /gen item} command string from a parsed NBT payload: an item
+ * carrying {@code minecraft:item_model} round-trips as {@code item_model}, everything else as
+ * {@code item_id}.
+ */
+class ParsedNbtCommandStringTest {
+
+    private static final String BASE = "/gen item item_name: &fSafari Belt";
+
+    @Test
+    void appendsItemIdWhenTheItemHasNoModel() {
+        assertEquals(BASE + " item_id: paper",
+            GeneratorCommands.appendParsedItemOptions(BASE, "paper", null, null, false));
+    }
+
+    @Test
+    void appendsItemModelInsteadOfItemIdWhenPresent() {
+        assertEquals(BASE + " item_model: hypixel_skyblock:item/island_relevant/safari/safari_belt",
+            GeneratorCommands.appendParsedItemOptions(BASE, "paper",
+                "hypixel_skyblock:item/island_relevant/safari/safari_belt", null, false));
+    }
+
+    @Test
+    void stripsTheMinecraftNamespaceFromTheItemIdOnly() {
+        assertEquals(BASE + " item_id: paper",
+            GeneratorCommands.appendParsedItemOptions(BASE, "minecraft:paper", null, null, false));
+        assertEquals(BASE + " item_model: minecraft:item/diamond_sword",
+            GeneratorCommands.appendParsedItemOptions(BASE, "minecraft:paper", "minecraft:item/diamond_sword", null, false));
+    }
+
+    @Test
+    void omitsBothWhenNeitherIsPresent() {
+        assertEquals(BASE, GeneratorCommands.appendParsedItemOptions(BASE, null, null, null, false));
+        assertEquals(BASE, GeneratorCommands.appendParsedItemOptions(BASE, "  ", "  ", null, false));
+    }
+
+    @Test
+    void appendsSkinValueAlongsideAnItemModel() {
+        assertEquals(BASE + " item_model: hypixel_skyblock:item/belt skin_value: abc123",
+            GeneratorCommands.appendParsedItemOptions(BASE, "player_head", "hypixel_skyblock:item/belt", "abc123", false));
+    }
+
+    @Test
+    void appendsEnchantedLast() {
+        assertEquals(BASE + " item_model: hypixel_skyblock:item/belt enchanted: True",
+            GeneratorCommands.appendParsedItemOptions(BASE, "paper", "hypixel_skyblock:item/belt", null, true));
+    }
+}

--- a/app/src/test/java/net/hypixel/nerdbot/app/command/ParsedNbtFallbackRenderTest.java
+++ b/app/src/test/java/net/hypixel/nerdbot/app/command/ParsedNbtFallbackRenderTest.java
@@ -1,0 +1,119 @@
+package net.hypixel.nerdbot.app.command;
+
+import net.aerh.imagegenerator.exception.GeneratorException;
+import net.aerh.imagegenerator.pack.PackId;
+import net.aerh.imagegenerator.pack.PackRepository;
+import net.hypixel.nerdbot.app.command.GeneratorCommands.ItemModelFallback;
+import net.hypixel.nerdbot.app.command.GeneratorCommands.ParsedRender;
+import net.hypixel.nerdbot.app.config.GeneratorConfig;
+import net.hypixel.nerdbot.app.generation.pack.ResourcePackService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The {@code /gen parse} render path: an item model the pack cannot produce degrades to a
+ * rendered stand-in instead of losing the whole preview, while failures that have nothing to do
+ * with item models still surface to the user.
+ */
+class ParsedNbtFallbackRenderTest {
+
+    private static final String RESOLVABLE = """
+        {"id":"minecraft:paper","components":{"minecraft:item_model":"testpack:item/simple"}}""";
+    private static final String UNRESOLVABLE = """
+        {"id":"minecraft:paper","components":{"minecraft:item_model":"testpack:item/never_shipped"}}""";
+
+    private ResourcePackService service;
+    private PackId packId;
+
+    @BeforeEach
+    void registerFixturePack() throws IOException {
+        // Fixtures live under target/ rather than @TempDir: pack sources are held open for the
+        // JVM's lifetime, so on Windows a temp-dir cleanup would fail to delete them.
+        Path root = Files.createDirectories(Path.of("target", "pack-fixtures"));
+        Path packDir = Files.createTempDirectory(root, "fallback-");
+        writeFixturePack(packDir);
+
+        service = new ResourcePackService(new PackRepository());
+        GeneratorConfig.PackDefinition definition = new GeneratorConfig.PackDefinition();
+        definition.setId("nerdbot:fallback");
+        definition.setPath(packDir.toString());
+        GeneratorConfig.ResourcePackConfig config = new GeneratorConfig.ResourcePackConfig();
+        config.setPacks(List.of(definition));
+        service.registerConfiguredPacks(config);
+        packId = PackId.parse("nerdbot:fallback");
+    }
+
+    @Test
+    void rendersTheModelWhenThePackShipsIt() throws IOException {
+        ParsedRender render = GeneratorCommands.renderParsedNbtWithFallback(service, RESOLVABLE, packId, null);
+
+        assertEquals(ItemModelFallback.NONE, render.fallback(), "a model the pack ships needs no stand-in");
+        assertNotNull(render.image());
+    }
+
+    @Test
+    void rendersTheBaseItemWhenThePackCannotProduceTheModel() throws IOException {
+        ParsedRender render = GeneratorCommands.renderParsedNbtWithFallback(service, UNRESOLVABLE, packId, null);
+
+        assertEquals(ItemModelFallback.ITEM_ID, render.fallback());
+        assertNotNull(render.image(), "the preview must still render rather than failing on a pack problem");
+        assertEquals("testpack:item/never_shipped", render.parsedNbt().getParsedItemModel(),
+            "the parse result still reports what the NBT asked for, so the notice can name it");
+    }
+
+    /**
+     * Note this asserts the error reaches the user, not that the retry was skipped: with no item
+     * model the stand-in would be the same item-id render that just failed, so both paths end in
+     * the same exception. The guard against retrying is an efficiency and logging concern, not an
+     * observable one.
+     */
+    @Test
+    void surfacesFailuresThatHaveNothingToDoWithItemModels() {
+        String unknownItem = """
+            {"id":"minecraft:not_a_real_item_at_all","components":{}}""";
+
+        GeneratorException exception = assertThrows(GeneratorException.class,
+            () -> GeneratorCommands.renderParsedNbtWithFallback(service, unknownItem, packId, null));
+
+        assertTrue(exception.getMessage().contains("Item with ID `not_a_real_item_at_all` not found"),
+            "a bad item id must reach the user rather than being swallowed: " + exception.getMessage());
+    }
+
+    private static void writeFixturePack(Path root) throws IOException {
+        write(root, "pack.mcmeta", "{\"pack\":{\"pack_format\":88,\"description\":\"fallback fixture\"}}");
+        write(root, "assets/testpack/items/item/simple.json",
+            "{\"model\":{\"type\":\"minecraft:model\",\"model\":\"testpack:item/simple\"}}");
+        write(root, "assets/testpack/models/item/simple.json",
+            "{\"textures\":{\"layer0\":\"testpack:item/simple\"}}");
+
+        BufferedImage texture = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = texture.createGraphics();
+        graphics.setColor(Color.MAGENTA);
+        graphics.fillRect(0, 0, 16, 16);
+        graphics.dispose();
+
+        Path png = root.resolve("assets/testpack/textures/item/simple.png");
+        Files.createDirectories(png.getParent());
+        ImageIO.write(texture, "png", png.toFile());
+    }
+
+    private static void write(Path root, String relative, String content) throws IOException {
+        Path target = root.resolve(relative);
+        Files.createDirectories(target.getParent());
+        Files.writeString(target, content);
+    }
+}


### PR DESCRIPTION
Depends on Aerhhh/MinecraftImageGenerator#72. This will not build until that merges and JitPack rebuilds `master-SNAPSHOT`.

## The bug

`/gen parse` on an item whose texture comes from `minecraft:item_model` reported `item_id: paper`. Copying that suggested command back into `/gen` rendered paper, because the model was never read. Reported for the Safari Belt (`hypixel_skyblock:item/island_relevant/safari/safari_belt`).

## What changed

`/gen parse` emits `item_model:` instead of `item_id:` when the NBT carries the component, so the round trip reproduces what was actually rendered.

`/gen display` and `/gen item` both take an `item_model` option, backed by the existing item name autocomplete. `item_id` on `/gen display` becomes optional now that a model can stand in for it. Passing both, or neither, is rejected with a message saying which, rather than silently picking one.

Worth noting `item_id` already accepted pack refs, which is why the interim workaround of pasting the model into `item_id` mostly worked. It breaks for `minecraft:`-namespace models, because `withItem` strips `minecraft:` globally rather than as a prefix. The explicit option avoids that.

## Fallback

A model the loaded pack cannot produce no longer loses the whole preview. The render retries with the player head skin if the NBT has one, otherwise with the base item id, and the reply carries a `-#` note naming the model that could not be found. This matters because the packs in production lag the pack items are authored against, so unresolvable models are routine rather than exceptional.

This is a try/catch on the render rather than an up-front resolvability check. A check was the first design, but it cannot deliver the guarantee: `PackRepository.itemRefs()` excludes items with malformed JSON but still includes items whose model file is missing, so a ref passing the check can still fail to render. Catching the actual failure is both accurate and avoids duplicating pack internals.

Failures unrelated to item models still surface to the user.

## Incidental fix

`applyPackTheme` passed a pack id to the tooltip builder without the matching pack repository, so tooltips resolved against the global repository while item renders used the injected one. Invisible in production because the bot's service wraps the global repository, but divergent for any service holding its own, which is what surfaced it in tests.

## Tests

20 new cases across three suites, all green (203 total):

- `ParsedNbtCommandStringTest` (6) covers what `/gen parse` emits
- `ItemModelAddressingTest` (11) covers namespace stripping, both/neither rejection, and fallback selection and notice text
- `ParsedNbtFallbackRenderTest` (3) renders against a fixture pack: model present, model missing, and a failure that must not be swallowed

## Deploy note

Slash commands need re-registering: `/gen display` and `/gen item` gained `item_model`, and `/gen display`'s `item_id` is now optional.
